### PR TITLE
Fix topic div being hidden on iOS devices

### DIFF
--- a/server/static/css/app.css
+++ b/server/static/css/app.css
@@ -373,10 +373,6 @@ li {
 }
 
 /** Detail view */
-#detail {
-    display: none;
-}
-
 #detail .detailDate {
     color: #888;
     font-size: 0.9em;


### PR DESCRIPTION
The default `display: none;` for the topic detail div was overriding the JS display changes made, so on iOS Safari / Chrome, the topic detail div would not show up.