### PR TITLE
Adjust RPM scriptlets to work on RHEL-flavour OSes, too.

### DIFF
--- a/scripts/postinst.sh
+++ b/scripts/postinst.sh
@@ -6,7 +6,7 @@ set -e
 #
 # TODO: This is only tested on Debian.
 #
-if [ "$1" = "configure" ] || [ "$1" = "1" ]; then
+if [ "$1" = "configure" ] || [ "$1" -gt 1 ]; then
   if [ -d /run/systemd/system ]; then
     # Create ntfy user/group
     id ntfy >/dev/null 2>&1 || useradd --system --no-create-home ntfy

--- a/scripts/postinst.sh
+++ b/scripts/postinst.sh
@@ -6,7 +6,7 @@ set -e
 #
 # TODO: This is only tested on Debian.
 #
-if [ "$1" = "configure" ] || [ "$1" -gt 1 ]; then
+if [ "$1" = "configure" ] || [ "$1" -ge 1 ]; then
   if [ -d /run/systemd/system ]; then
     # Create ntfy user/group
     id ntfy >/dev/null 2>&1 || useradd --system --no-create-home ntfy

--- a/scripts/postinst.sh
+++ b/scripts/postinst.sh
@@ -6,33 +6,34 @@ set -e
 #
 # TODO: This is only tested on Debian.
 #
-if ( [ "$1" = "configure" ] || [ "$1" = "1" ] ) && [ -d /run/systemd/system ]; then
-  # Create ntfy user/group
-  id ntfy >/dev/null 2>&1 || useradd --system --no-create-home ntfy
-  chown ntfy.ntfy /var/cache/ntfy
-  chmod 700 /var/cache/ntfy
+if [ "$1" = "configure" ] || [ "$1" = "1" ]; then
+  if [ -d /run/systemd/system ]; then
+    # Create ntfy user/group
+    id ntfy >/dev/null 2>&1 || useradd --system --no-create-home ntfy
+    chown ntfy.ntfy /var/cache/ntfy
+    chmod 700 /var/cache/ntfy
 
-  # Hack to change permissions on cache file
-  configfile="/etc/ntfy/server.yml"
-  if [ -f "$configfile" ]; then
-    cachefile="$(cat "$configfile" | perl -n -e'/^\s*cache-file: ["'"'"']?([^"'"'"']+)["'"'"']?/ && print $1')" # Oh my, see #47
-    if [ -n "$cachefile" ]; then
-      chown ntfy.ntfy "$cachefile" || true
-      chmod 600 "$cachefile" || true
+    # Hack to change permissions on cache file
+    configfile="/etc/ntfy/server.yml"
+    if [ -f "$configfile" ]; then
+      cachefile="$(cat "$configfile" | perl -n -e'/^\s*cache-file: ["'"'"']?([^"'"'"']+)["'"'"']?/ && print $1')" # Oh my, see #47
+      if [ -n "$cachefile" ]; then
+        chown ntfy.ntfy "$cachefile" || true
+        chmod 600 "$cachefile" || true
+      fi
     fi
-  fi
 
-  # Restart services
-  systemctl --system daemon-reload >/dev/null || true
-  if systemctl is-active -q ntfy.service; then
-    echo "Restarting ntfy.service ..."
-    if [ -x /usr/bin/deb-systemd-invoke ]; then
-      deb-systemd-invoke try-restart ntfy.service >/dev/null || true
-    else
-      systemctl restart ntfy.service >/dev/null || true
+    # Restart services
+    systemctl --system daemon-reload >/dev/null || true
+    if systemctl is-active -q ntfy.service; then
+      echo "Restarting ntfy.service ..."
+      if [ -x /usr/bin/deb-systemd-invoke ]; then
+        deb-systemd-invoke try-restart ntfy.service >/dev/null || true
+      else
+        systemctl restart ntfy.service >/dev/null || true
+      fi
     fi
-  fi
-  if systemctl is-active -q ntfy-client.service; then
+    if systemctl is-active -q ntfy-client.service; then
       echo "Restarting ntfy-client.service ..."
       if [ -x /usr/bin/deb-systemd-invoke ]; then
         deb-systemd-invoke try-restart ntfy-client.service >/dev/null || true
@@ -40,4 +41,5 @@ if ( [ "$1" = "configure" ] || [ "$1" = "1" ] ) && [ -d /run/systemd/system ]; t
         systemctl restart ntfy-client.service >/dev/null || true
       fi
     fi
+  fi
 fi

--- a/scripts/postinst.sh
+++ b/scripts/postinst.sh
@@ -6,7 +6,7 @@ set -e
 #
 # TODO: This is only tested on Debian.
 #
-if [ "$1" = "configure" ] && [ -d /run/systemd/system ]; then
+if ( [ "$1" = "configure" ] || [ "$1" = "1" ] ) && [ -d /run/systemd/system ]; then
   # Create ntfy user/group
   id ntfy >/dev/null 2>&1 || useradd --system --no-create-home ntfy
   chown ntfy.ntfy /var/cache/ntfy

--- a/scripts/postrm.sh
+++ b/scripts/postrm.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Delete the config if package is purged
-if [ "$1" = "purge" ]; then
+if [ "$1" = "purge" ] || [ "$1" = "0" ]; then
   id ntfy >/dev/null 2>&1 && userdel ntfy
   rm -f /etc/ntfy/server.yml /etc/ntfy/client.yml
   rmdir /etc/ntfy || true

--- a/scripts/preinst.sh
+++ b/scripts/preinst.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "install" ] || [ "$1" = "upgrade" ] || [ "$1" -gt 1 ]; then
+if [ "$1" = "install" ] || [ "$1" = "upgrade" ] || [ "$1" -ge 1 ]; then
   # Migration of old to new config file name
   oldconfigfile="/etc/ntfy/config.yml"
   configfile="/etc/ntfy/server.yml"

--- a/scripts/preinst.sh
+++ b/scripts/preinst.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "install" ] || [ "$1" = "upgrade" ]; then
+if [ "$1" = "install" ] || [ "$1" = "upgrade" ] || [ "$1" = "1" ]; then
   # Migration of old to new config file name
   oldconfigfile="/etc/ntfy/config.yml"
   configfile="/etc/ntfy/server.yml"

--- a/scripts/preinst.sh
+++ b/scripts/preinst.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "install" ] || [ "$1" = "upgrade" ] || [ "$1" = "1" ]; then
+if [ "$1" = "install" ] || [ "$1" = "upgrade" ] || [ "$1" -gt 1 ]; then
   # Migration of old to new config file name
   oldconfigfile="/etc/ntfy/config.yml"
   configfile="/etc/ntfy/server.yml"

--- a/scripts/prerm.sh
+++ b/scripts/prerm.sh
@@ -3,7 +3,7 @@ set -e
 
 # Stop systemd service
 if [ -d /run/systemd/system ]; then
-  if [ "$1" = remove ] || [ "$1" = "0" ]; then
+  if [ "$1" = "remove" ] || [ "$1" = "0" ]; then
     echo "Stopping ntfy.service ..."
     if [ -x /usr/bin/deb-systemd-invoke ]; then
       deb-systemd-invoke stop 'ntfy.service' >/dev/null || true

--- a/scripts/prerm.sh
+++ b/scripts/prerm.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Stop systemd service
-if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
+if [ -d /run/systemd/system ] && ( [ "$1" = remove ] || [ "$1" = "0" ] ); then
   echo "Stopping ntfy.service ..."
   if [ -x /usr/bin/deb-systemd-invoke ]; then
     deb-systemd-invoke stop 'ntfy.service' >/dev/null || true

--- a/scripts/prerm.sh
+++ b/scripts/prerm.sh
@@ -2,11 +2,13 @@
 set -e
 
 # Stop systemd service
-if [ -d /run/systemd/system ] && ( [ "$1" = remove ] || [ "$1" = "0" ] ); then
-  echo "Stopping ntfy.service ..."
-  if [ -x /usr/bin/deb-systemd-invoke ]; then
-    deb-systemd-invoke stop 'ntfy.service' >/dev/null || true
-  else
-    systemctl stop ntfy >/dev/null 2>&1 || true
+if [ -d /run/systemd/system ]; then
+  if [ "$1" = remove ] || [ "$1" = "0" ]; then
+    echo "Stopping ntfy.service ..."
+    if [ -x /usr/bin/deb-systemd-invoke ]; then
+      deb-systemd-invoke stop 'ntfy.service' >/dev/null || true
+    else
+      systemctl stop ntfy >/dev/null 2>&1 || true
+    fi
   fi
 fi


### PR DESCRIPTION
I suppose in prerm.sh the existing
```
[ "$1" = remove ]
```
should be a
```
[ "$1" = "remove" ]
```
too?