### PR TITLE
Add authentification support for subscribing with CLI

### DIFF
--- a/client/client.yml
+++ b/client/client.yml
@@ -16,6 +16,10 @@
 #         command: 'echo "$message"'
 #         if:
 #             priority: high,urgent
+#       - topic: secret
+#         command: 'notify-send "$m"'
+#         user: phill
+#         password: mypass
 #
 # Variables:
 #     Variable        Aliases               Description

--- a/client/config.go
+++ b/client/config.go
@@ -14,9 +14,11 @@ const (
 type Config struct {
 	DefaultHost string `yaml:"default-host"`
 	Subscribe   []struct {
-		Topic   string            `yaml:"topic"`
-		Command string            `yaml:"command"`
-		If      map[string]string `yaml:"if"`
+		Topic    string            `yaml:"topic"`
+		User     string            `yaml:"user"`
+		Password string            `yaml:"password"`
+		Command  string            `yaml:"command"`
+		If       map[string]string `yaml:"if"`
 	} `yaml:"subscribe"`
 }
 

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -13,7 +13,9 @@ func TestConfig_Load(t *testing.T) {
 	require.Nil(t, os.WriteFile(filename, []byte(`
 default-host: http://localhost
 subscribe:
-  - topic: no-command
+  - topic: no-command-with-auth
+    user: phil
+    password: mypass
   - topic: echo-this
     command: 'echo "Message received: $message"'
   - topic: alerts
@@ -26,8 +28,10 @@ subscribe:
 	require.Nil(t, err)
 	require.Equal(t, "http://localhost", conf.DefaultHost)
 	require.Equal(t, 3, len(conf.Subscribe))
-	require.Equal(t, "no-command", conf.Subscribe[0].Topic)
+	require.Equal(t, "no-command-with-auth", conf.Subscribe[0].Topic)
 	require.Equal(t, "", conf.Subscribe[0].Command)
+	require.Equal(t, "phil", conf.Subscribe[0].User)
+	require.Equal(t, "mypass", conf.Subscribe[0].Password)
 	require.Equal(t, "echo-this", conf.Subscribe[1].Topic)
 	require.Equal(t, `echo "Message received: $message"`, conf.Subscribe[1].Command)
 	require.Equal(t, "alerts", conf.Subscribe[2].Topic)

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -162,6 +162,9 @@ func doSubscribe(c *cli.Context, cl *client.Client, conf *client.Config, topic, 
 		for filter, value := range s.If {
 			topicOptions = append(topicOptions, client.WithFilter(filter, value))
 		}
+		if s.User != "" && s.Password != "" {
+			topicOptions = append(topicOptions, client.WithBasicAuth(s.User, s.Password))
+		}
 		subscriptionID := cl.Subscribe(s.Topic, topicOptions...)
 		commands[subscriptionID] = s.Command
 	}

--- a/docs/subscribe/cli.md
+++ b/docs/subscribe/cli.md
@@ -196,3 +196,27 @@ EOF
 sudo systemctl daemon-reload
 sudo systemctl restart ntfy-client
 ```
+
+
+### Authentication
+Depending on whether the server is configured to support [access control](../config.md#access-control), some topics
+may be read/write protected so that only users with the correct credentials can subscribe or publish to them.
+To publish/subscribe to protected topics, you can use [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication)
+with a valid username/password. For your self-hosted server, **be sure to use HTTPS to avoid eavesdropping** and exposing
+your password. 
+
+You can either add your username and password to the configuration file:
+=== "~/.config/ntfy/client.yml"
+	```yaml
+	 - topic: secret
+	   command: 'notify-send "$m"'
+	   user: phill
+	   password: mypass
+	```
+
+Or with the `ntfy subscibe` command:
+```
+ntfy subscribe \
+  -u phil:mypass \
+  ntfy.example.com/mysecrets
+```


### PR DESCRIPTION
I added `-u username[:password]` parameter to `ntfy subscribe` just like the one in `ntfy publish`.
I also added `user` and `password` key for each subscription in `client.yml`.

Close #147