### PR TITLE
Add support for iOS app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo "  make build                       - Build"
 	@echo "  make build-snapshot              - Build snapshot"
 	@echo "  make build-simple                - Build (using go build, without goreleaser)"
+	@echo "  make build-simple-darwin         - Build (using go build, without goreleaser) on macOS systems"
 	@echo "  make clean                       - Clean build folder"
 	@echo
 	@echo "Releasing (requires goreleaser):"
@@ -113,6 +114,17 @@ build-simple: clean
 		-tags sqlite_omit_load_extension,osusergo,netgo \
 		-ldflags \
 		"-linkmode=external -extldflags=-static -s -w -X main.version=$(VERSION) -X main.commit=$(shell git rev-parse --short HEAD) -X main.date=$(shell date +%s)"
+
+build-simple-darwin: clean
+	mkdir -p dist/ntfy_linux_amd64 server/docs
+	touch server/docs/dummy
+	export CGO_ENABLED=1
+	go build \
+		-o dist/ntfy_linux_amd64/ntfy \
+		-tags sqlite_omit_load_extension,osusergo,netgo \
+		-ldflags \
+		"-linkmode=external -s -w -X main.version=$(VERSION) -X main.commit=$(shell git rev-parse --short HEAD) -X main.date=$(shell date +%s)"
+
 
 clean: .PHONY
 	rm -rf dist build server/docs

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -20,6 +20,7 @@ Build:
   make build                       - Build
   make build-snapshot              - Build snapshot
   make build-simple                - Build (using go build, without goreleaser)
+  make build-simple-darwin         - Build (using go build, without goreleaser) on macOS systems
   make clean                       - Clean build folder
 
 Releasing (requires goreleaser):

--- a/server/server_firebase.go
+++ b/server/server_firebase.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	fcmMessageLimit = 4000
+	fcmMessageLimit         = 4000
 	fcmApnsBodyMessageLimit = 100
 )
 

--- a/server/server_firebase_test.go
+++ b/server/server_firebase_test.go
@@ -32,6 +32,7 @@ func TestToFirebaseMessage_Keepalive(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "mytopic", fbm.Topic)
 	require.Nil(t, fbm.Android)
+	require.Nil(t, fbm.APNS)
 	require.Equal(t, map[string]string{
 		"id":    m.ID,
 		"time":  fmt.Sprintf("%d", m.Time),
@@ -46,6 +47,7 @@ func TestToFirebaseMessage_Open(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "mytopic", fbm.Topic)
 	require.Nil(t, fbm.Android)
+	require.Nil(t, fbm.APNS)
 	require.Equal(t, map[string]string{
 		"id":    m.ID,
 		"time":  fmt.Sprintf("%d", m.Time),
@@ -74,6 +76,17 @@ func TestToFirebaseMessage_Message_Normal_Allowed(t *testing.T) {
 	require.Equal(t, &messaging.AndroidConfig{
 		Priority: "high",
 	}, fbm.Android)
+	require.Equal(t, &messaging.APNSConfig{
+		Payload: &messaging.APNSPayload{
+			Aps: &messaging.Aps{
+				MutableContent: true,
+				Alert: &messaging.ApsAlert{
+					Title: "some title",
+					Body:  "this is a message",
+				},
+			},
+		},
+	}, fbm.APNS)
 	require.Equal(t, map[string]string{
 		"id":                 m.ID,
 		"time":               fmt.Sprintf("%d", m.Time),
@@ -102,6 +115,7 @@ func TestToFirebaseMessage_Message_Normal_Not_Allowed(t *testing.T) {
 	require.Equal(t, &messaging.AndroidConfig{
 		Priority: "high",
 	}, fbm.Android)
+	require.Nil(t, fbm.APNS)
 	require.Equal(t, "", fbm.Data["message"])
 	require.Equal(t, "", fbm.Data["priority"])
 	require.Equal(t, map[string]string{
@@ -128,6 +142,17 @@ func TestMaybeTruncateFCMMessage(t *testing.T) {
 		},
 		Android: &messaging.AndroidConfig{
 			Priority: "high",
+		},
+		APNS: &messaging.APNSConfig{
+			Payload: &messaging.APNSPayload{
+				Aps: &messaging.Aps{
+					MutableContent: true,
+					Alert: &messaging.ApsAlert{
+						Title: "some title",
+						Body:  maybeTruncateAPNSBodyMessage(origMessage),
+					},
+				},
+			},
 		},
 	}
 	origMessageLength := len(origFCMMessage.Data["message"])

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -156,7 +156,7 @@ func TestServer_StaticSites(t *testing.T) {
 	require.Equal(t, 301, rr.Code)
 
 	rr = request(t, s, "GET", "/docs/", "", nil)
-	require.Equal(t, 200, rr.Code)
+	require.Equal(t, 200, rr.Code) // Test will fail if docs have not yet been built
 	require.Contains(t, rr.Body.String(), `Made with ❤️ by Philipp C. Heckel`)
 	require.Contains(t, rr.Body.String(), `<script src=static/js/extra.js></script>`)
 


### PR DESCRIPTION
Initial support for the iOS app.

TODOs:
- [ ] APNS payload - add sound/vibrate
- [ ] Send "poll_request"APNS payload
- [ ] Look into message/payload length limits (note: if payload is too large, APNS will not deliver the notification)