### PR TITLE
Force MAKEFLAGS to --jobs=1 to ensure dependencies are executed sequentially and in correct order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+MAKEFLAGS := --jobs=1
 VERSION := $(shell git describe --tag)
 
 .PHONY:


### PR DESCRIPTION
If this is not set, make -j2 web or higher job counts will
cause the build to fail as some dependencies are not expressed
directly on the dependent tasks but as a dependency list
on a parent task.

Alternatively one could add the required dependencies for each
task separately, but that would factually sequentiallize the
build, so there's no real difference except this approach
fixes all dependency chains globally.