### PR TITLE
Docs/config: fix typo in private server example

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -227,7 +227,7 @@ The easiest way to configure a private instance is to set `auth-default-access` 
 
 === "/etc/ntfy/server.yml"
     ``` yaml
-    auth-file "/var/lib/ntfy/user.db"
+    auth-file: "/var/lib/ntfy/user.db"
     auth-default-access: "deny-all"
     ```
 


### PR DESCRIPTION
The `/etc/ntfy/server.yml` example was invalid yaml previously.

That's the config I'm using, so it works :)