### PR TITLE
update docs to explain attachment name and URL in broadcast intent

### DIFF
--- a/docs/subscribe/phone.md
+++ b/docs/subscribe/phone.md
@@ -181,6 +181,8 @@ Here's a list of extras you can access. Most likely, you'll want to filter for `
 | `tags`          | *String*                     | `tag1,tag2,..`     | Comma-separated list of [tags](../publish.md#tags-emojis)                          |
 | `tags_map`      | *String*                     | `0=tag1,1=tag2,..` | Map of tags to make it easier to map first, second, ... tag                        |
 | `priority`      | *Int (between 1-5)*          | `4`                | Message [priority](../publish.md#message-priority) with 1=min, 3=default and 5=max |
+| `attachment_name`| *String*                    | `attachment.jpg`   | The filename of the attachment; may be empty if not set                            |
+| `attachment_url`| *String*                     | `https://ntfy.sh/file/afUbjadfl7ErP.jpg` | The URL of the attachment on the server; may be empty if not set |
 
 #### Send messages using intents
 To send messages from other apps (such as [MacroDroid](https://play.google.com/store/apps/details?id=com.arlosoft.macrodroid)


### PR DESCRIPTION
adds docs for #329 

The field names (`attachment_name` and `attachment_url`) are 1 character too long to fit on one line in the column unfortunately. I couldn't figure out how to make the first column wider so it didn't wrap.

![image](https://user-images.githubusercontent.com/8421688/174306598-076cbd6a-7356-40c7-b304-8e473cca8a73.png)
