### PR TITLE
allow custom intent in broadcast action without JSON

### DIFF
--- a/server/actions.go
+++ b/server/actions.go
@@ -186,6 +186,8 @@ func populateAction(newAction *action, section int, key, value string) error {
 			newAction.Method = value
 		case "body":
 			newAction.Body = value
+    case "intent":
+      newAction.Intent = value
 		default:
 			return fmt.Errorf("key '%s' unknown", key)
 		}

--- a/server/actions_test.go
+++ b/server/actions_test.go
@@ -52,6 +52,14 @@ func TestParseActions(t *testing.T) {
 	require.Equal(t, "some command", actions[0].Extras["command"])
 	require.Equal(t, "a parameter", actions[0].Extras["some_param"])
 
+  // Broadcast action with intent
+  actions, err = parseActions("action=broadcast, label=Do a thing, intent=io.heckel.ntfy.TEST_INTENT")
+  require.Nil(t, err)
+  require.Equal(t, 1, len(actions))
+  require.Equal(t, "broadcast", actions[0].Action)
+  require.Equal(t, "Do a thing", actions[0].Label)
+  require.Equal(t, "io.heckel.ntfy.TEST_INTENT", actions[0].Intent)
+
 	// Headers with dashes
 	actions, err = parseActions("action=http, label=Send request, url=http://example.com, method=GET, headers.Content-Type=application/json, headers.Authorization=Basic sdasffsf")
 	require.Nil(t, err)


### PR DESCRIPTION
I noticed you could only change the intent of a broadcast action using the JSON publishing format. This allows you to specify the intent as a key/value pair in the Actions header