### PR TITLE
Document Matrix pushkey error + set log level to warnings for Matrix errors

### DIFF
--- a/server/server_matrix.go
+++ b/server/server_matrix.go
@@ -124,7 +124,7 @@ func newRequestFromMatrixJSON(r *http.Request, baseURL string, messageLimit int)
 	}
 	pushKey := m.Notification.Devices[0].PushKey // We ignore other devices for now, see discussion in #316
 	if !strings.HasPrefix(pushKey, baseURL+"/") {
-		return nil, &errMatrix{pushKey: pushKey, err: errHTTPBadRequestMatrixPushkeyBaseURLMismatch}
+		return nil, &errMatrix{pushKey: pushKey, err: wrapErrHTTP(errHTTPBadRequestMatrixPushkeyBaseURLMismatch, "; received pushKey: %s, configured base url: %s", pushKey, baseURL)}
 	}
 	newRequest, err := http.NewRequest(http.MethodPost, pushKey, io.NopCloser(bytes.NewReader(body.PeekedBytes)))
 	if err != nil {


### PR DESCRIPTION
The rationale is to clearly indicate what is set in the configuration compared to what was received in the request for debug purpose. Also, Matrix request errors now logs in warning level. I believe this can be disturbing having your setup not working and no error being logged in the default log level.