### PR TITLE
Allow Exempting IP Ranges

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -306,31 +306,30 @@ func sigHandlerConfigReload(config string) {
 }
 
 func parseIPHostPrefix(host string) (prefixes []netip.Prefix, err error) {
-        //try parsing as prefix
-        prefix, err := netip.ParsePrefix(host)
-        if err == nil {
-                prefixes = append(prefixes, prefix.Masked()) // masked and canonical for easy of debugging, shouldn't matter
-                return prefixes, nil                         // success
-        }
+	//try parsing as prefix
+	prefix, err := netip.ParsePrefix(host)
+	if err == nil {
+		prefixes = append(prefixes, prefix.Masked()) // Masked returns the prefix in its canonical form,  the same for every ip in the range. This exists for ease of debugging. For example, 10.1.2.3/16 is 10.1.0.0/16.
+		return prefixes, nil                         // success
+	}
 
-        // not a prefix, parse as host or IP
-        // LookupHost forwards through if it's an IP
-        ips, err := net.LookupHost(host)
-        if err == nil {
-                for _, i := range ips {
-                        ip, err := netip.ParseAddr(i)
-                        if err == nil {
-                                prefix, err := ip.Prefix(ip.BitLen())
-                                if err != nil {
-                                        return prefixes, errors.New(fmt.Sprint("ip", ip, " successfully parsed as IP but unable to turn into prefix. THIS SHOULD NEVER HAPPEN. err:", err.Error()))
-                                }
-                                prefixes = append(prefixes, prefix.Masked()) //also masked canonical ip
-                        }
-                }
-        }
-        return
+	// not a prefix, parse as host or IP
+	// LookupHost forwards through if it's an IP
+	ips, err := net.LookupHost(host)
+	if err == nil {
+		for _, i := range ips {
+			ip, err := netip.ParseAddr(i)
+			if err == nil {
+				prefix, err := ip.Prefix(ip.BitLen())
+				if err != nil {
+					return prefixes, errors.New(fmt.Sprint("ip", ip, " successfully parsed as IP but unable to turn into prefix. THIS SHOULD NEVER HAPPEN. err:", err.Error()))
+				}
+				prefixes = append(prefixes, prefix.Masked()) //also masked canonical ip
+			}
+		}
+	}
+	return
 }
-
 
 func reloadLogLevel(inputSource altsrc.InputSourceContext) {
 	newLevelStr, err := inputSource.String("log-level")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -217,9 +217,7 @@ func execServe(c *cli.Context) error {
 			log.Warn("cannot resolve host %s: %s, ignoring visitor request exemption", host, err.Error())
 			continue
 		}
-		for _, ip := range ips {
-			visitorRequestLimitExemptIPs = append(visitorRequestLimitExemptIPs, ip)
-		}
+		visitorRequestLimitExemptIPs = append(visitorRequestLimitExemptIPs, ips...)
 	}
 
 	// Run server

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -314,18 +314,19 @@ func parseIPHostPrefix(host string) (prefixes []netip.Prefix, err error) {
 	}
 
 	// not a prefix, parse as host or IP
-	// LookupHost forwards through if it's an IP
+	// LookupHost passes through an IP as is
 	ips, err := net.LookupHost(host)
-	if err == nil {
-		for _, i := range ips {
-			ip, err := netip.ParseAddr(i)
-			if err == nil {
-				prefix, err := ip.Prefix(ip.BitLen())
-				if err != nil {
-					return prefixes, errors.New(fmt.Sprint("ip", ip, " successfully parsed as IP but unable to turn into prefix. THIS SHOULD NEVER HAPPEN. err:", err.Error()))
-				}
-				prefixes = append(prefixes, prefix.Masked()) //also masked canonical ip
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range ips {
+		ip, err := netip.ParseAddr(i)
+		if err == nil {
+			prefix, err := ip.Prefix(ip.BitLen())
+			if err != nil {
+				return nil, fmt.Errorf("%s successfully parsed but unable to make prefix: %s", ip.String(), err.Error())
 			}
+			prefixes = append(prefixes, prefix.Masked()) //also masked canonical ip
 		}
 	}
 	return

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2,17 +2,19 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/require"
-	"heckel.io/ntfy/client"
-	"heckel.io/ntfy/test"
-	"heckel.io/ntfy/util"
 	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"heckel.io/ntfy/client"
+	"heckel.io/ntfy/test"
+	"heckel.io/ntfy/util"
 )
 
 func init() {
@@ -68,6 +70,22 @@ func TestCLI_Serve_WebSocket(t *testing.T) {
 	m := toMessage(t, string(data))
 	require.Equal(t, "my message", m.Message)
 	require.Equal(t, "mytopic", m.Topic)
+}
+
+func TestIP_Host_Parsing(t *testing.T) {
+	cases := map[string]string{
+		"1.1.1.1":          "1.1.1.1/32",
+		"fd00::1234":       "fd00::1234/128",
+		"192.168.0.3/24":   "192.168.0.0/24",
+		"10.1.2.3/8":       "10.0.0.0/8",
+		"201:be93::4a6/21": "201:b800::/21",
+	}
+	for q, expectedAnswer := range cases {
+		ips, err := parseIPHostPrefix(q)
+		require.Nil(t, err)
+		assert.Equal(t, 1, len(ips))
+		assert.Equal(t, expectedAnswer, ips[0].String())
+	}
 }
 
 func newEmptyFile(t *testing.T) string {

--- a/server/config.go
+++ b/server/config.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"io/fs"
+	"net/netip"
 	"time"
 )
 
@@ -92,7 +93,7 @@ type Config struct {
 	VisitorAttachmentDailyBandwidthLimit int
 	VisitorRequestLimitBurst             int
 	VisitorRequestLimitReplenish         time.Duration
-	VisitorRequestExemptIPAddrs          []string
+	VisitorRequestExemptIPAddrs          []netip.Prefix
 	VisitorEmailLimitBurst               int
 	VisitorEmailLimitReplenish           time.Duration
 	BehindProxy                          bool
@@ -135,7 +136,7 @@ func NewConfig() *Config {
 		VisitorAttachmentDailyBandwidthLimit: DefaultVisitorAttachmentDailyBandwidthLimit,
 		VisitorRequestLimitBurst:             DefaultVisitorRequestLimitBurst,
 		VisitorRequestLimitReplenish:         DefaultVisitorRequestLimitReplenish,
-		VisitorRequestExemptIPAddrs:          make([]string, 0),
+		VisitorRequestExemptIPAddrs:          make([]netip.Prefix, 0),
 		VisitorEmailLimitBurst:               DefaultVisitorEmailLimitBurst,
 		VisitorEmailLimitReplenish:           DefaultVisitorEmailLimitReplenish,
 		BehindProxy:                          false,

--- a/server/message_cache.go
+++ b/server/message_cache.go
@@ -456,6 +456,11 @@ func readMessages(rows *sql.Rows) ([]*message, error) {
 				return nil, err
 			}
 		}
+		senderIP, err := netip.ParseAddr(sender)
+		if err != nil {
+			senderIP = netip.IPv4Unspecified() // if no IP stored in database, 0.0.0.0
+		}
+
 		var att *attachment
 		if attachmentName != "" && attachmentURL != "" {
 			att = &attachment{
@@ -479,7 +484,7 @@ func readMessages(rows *sql.Rows) ([]*message, error) {
 			Icon:       icon,
 			Actions:    actions,
 			Attachment: att,
-			Sender:     netip.MustParseAddr(sender), // Must parse assuming database must be correct
+			Sender:     senderIP, // Must parse assuming database must be correct
 			Encoding:   encoding,
 		})
 	}

--- a/server/message_cache.go
+++ b/server/message_cache.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/netip"
+	"strings"
+	"time"
+
 	_ "github.com/mattn/go-sqlite3" // SQLite driver
 	"heckel.io/ntfy/log"
 	"heckel.io/ntfy/util"
-	"strings"
-	"time"
 )
 
 var (
@@ -279,7 +281,7 @@ func (c *messageCache) addMessages(ms []*message) error {
 			attachmentSize,
 			attachmentExpires,
 			attachmentURL,
-			m.Sender,
+			m.Sender.String(),
 			m.Encoding,
 			published,
 		)
@@ -477,7 +479,7 @@ func readMessages(rows *sql.Rows) ([]*message, error) {
 			Icon:       icon,
 			Actions:    actions,
 			Attachment: att,
-			Sender:     sender,
+			Sender:     netip.MustParseAddr(sender), // Must parse assuming database must be correct
 			Encoding:   encoding,
 		})
 	}

--- a/server/message_cache_test.go
+++ b/server/message_cache_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	exampleIP1234 = netip.MustParseAddr("1.2.3.4")
+)
+
 func TestSqliteCache_Messages(t *testing.T) {
 	testCacheMessages(t, newSqliteTestCache(t))
 }
@@ -283,7 +287,7 @@ func testCacheAttachments(t *testing.T, c *messageCache) {
 	expires1 := time.Now().Add(-4 * time.Hour).Unix()
 	m := newDefaultMessage("mytopic", "flower for you")
 	m.ID = "m1"
-	m.Sender = netip.MustParseAddr("1.2.3.4")
+	m.Sender = exampleIP1234
 	m.Attachment = &attachment{
 		Name:    "flower.jpg",
 		Type:    "image/jpeg",
@@ -296,7 +300,7 @@ func testCacheAttachments(t *testing.T, c *messageCache) {
 	expires2 := time.Now().Add(2 * time.Hour).Unix() // Future
 	m = newDefaultMessage("mytopic", "sending you a car")
 	m.ID = "m2"
-	m.Sender = netip.MustParseAddr("1.2.3.4")
+	m.Sender = exampleIP1234
 	m.Attachment = &attachment{
 		Name:    "car.jpg",
 		Type:    "image/jpeg",
@@ -309,7 +313,7 @@ func testCacheAttachments(t *testing.T, c *messageCache) {
 	expires3 := time.Now().Add(1 * time.Hour).Unix() // Future
 	m = newDefaultMessage("another-topic", "sending you another car")
 	m.ID = "m3"
-	m.Sender = netip.MustParseAddr("1.2.3.4")
+	m.Sender = exampleIP1234
 	m.Attachment = &attachment{
 		Name:    "another-car.jpg",
 		Type:    "image/jpeg",
@@ -329,7 +333,7 @@ func testCacheAttachments(t *testing.T, c *messageCache) {
 	require.Equal(t, int64(5000), messages[0].Attachment.Size)
 	require.Equal(t, expires1, messages[0].Attachment.Expires)
 	require.Equal(t, "https://ntfy.sh/file/AbDeFgJhal.jpg", messages[0].Attachment.URL)
-	require.Equal(t, "1.2.3.4", messages[0].Sender)
+	require.Equal(t, "1.2.3.4", messages[0].Sender.String())
 
 	require.Equal(t, "sending you a car", messages[1].Message)
 	require.Equal(t, "car.jpg", messages[1].Attachment.Name)
@@ -337,7 +341,7 @@ func testCacheAttachments(t *testing.T, c *messageCache) {
 	require.Equal(t, int64(10000), messages[1].Attachment.Size)
 	require.Equal(t, expires2, messages[1].Attachment.Expires)
 	require.Equal(t, "https://ntfy.sh/file/aCaRURL.jpg", messages[1].Attachment.URL)
-	require.Equal(t, "1.2.3.4", messages[1].Sender)
+	require.Equal(t, "1.2.3.4", messages[1].Sender.String())
 
 	size, err := c.AttachmentBytesUsed("1.2.3.4")
 	require.Nil(t, err)

--- a/server/message_cache_test.go
+++ b/server/message_cache_test.go
@@ -3,11 +3,13 @@ package server
 import (
 	"database/sql"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"net/netip"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSqliteCache_Messages(t *testing.T) {
@@ -281,7 +283,7 @@ func testCacheAttachments(t *testing.T, c *messageCache) {
 	expires1 := time.Now().Add(-4 * time.Hour).Unix()
 	m := newDefaultMessage("mytopic", "flower for you")
 	m.ID = "m1"
-	m.Sender = "1.2.3.4"
+	m.Sender = netip.MustParseAddr("1.2.3.4")
 	m.Attachment = &attachment{
 		Name:    "flower.jpg",
 		Type:    "image/jpeg",
@@ -294,7 +296,7 @@ func testCacheAttachments(t *testing.T, c *messageCache) {
 	expires2 := time.Now().Add(2 * time.Hour).Unix() // Future
 	m = newDefaultMessage("mytopic", "sending you a car")
 	m.ID = "m2"
-	m.Sender = "1.2.3.4"
+	m.Sender = netip.MustParseAddr("1.2.3.4")
 	m.Attachment = &attachment{
 		Name:    "car.jpg",
 		Type:    "image/jpeg",
@@ -307,7 +309,7 @@ func testCacheAttachments(t *testing.T, c *messageCache) {
 	expires3 := time.Now().Add(1 * time.Hour).Unix() // Future
 	m = newDefaultMessage("another-topic", "sending you another car")
 	m.ID = "m3"
-	m.Sender = "1.2.3.4"
+	m.Sender = netip.MustParseAddr("1.2.3.4")
 	m.Attachment = &attachment{
 		Name:    "another-car.jpg",
 		Type:    "image/jpeg",

--- a/server/server_firebase_test.go
+++ b/server/server_firebase_test.go
@@ -3,13 +3,15 @@ package server
 import (
 	"encoding/json"
 	"errors"
-	"firebase.google.com/go/v4/messaging"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"heckel.io/ntfy/auth"
+	"net/netip"
 	"strings"
 	"sync"
 	"testing"
+
+	"firebase.google.com/go/v4/messaging"
+	"github.com/stretchr/testify/require"
+	"heckel.io/ntfy/auth"
 )
 
 type testAuther struct {
@@ -322,7 +324,7 @@ func TestMaybeTruncateFCMMessage_NotTooLong(t *testing.T) {
 func TestToFirebaseSender_Abuse(t *testing.T) {
 	sender := &testFirebaseSender{allowed: 2}
 	client := newFirebaseClient(sender, &testAuther{})
-	visitor := newVisitor(newTestConfig(t), newMemTestCache(t), "1.2.3.4")
+	visitor := newVisitor(newTestConfig(t), newMemTestCache(t), netip.MustParseAddr("1.2.3.4"))
 
 	require.Nil(t, client.Send(visitor, &message{Topic: "mytopic"}))
 	require.Equal(t, 1, len(sender.Messages()))

--- a/server/server_matrix_test.go
+++ b/server/server_matrix_test.go
@@ -1,11 +1,13 @@
 package server
 
 import (
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMatrix_NewRequestFromMatrixJSON_Success(t *testing.T) {
@@ -70,7 +72,7 @@ func TestMatrix_WriteMatrixDiscoveryResponse(t *testing.T) {
 func TestMatrix_WriteMatrixError(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("POST", "http://ntfy.example.com/_matrix/push/v1/notify", nil)
-	v := newVisitor(newTestConfig(t), nil, "1.2.3.4")
+	v := newVisitor(newTestConfig(t), nil, netip.MustParseAddr("1.2.3.4"))
 	require.Nil(t, writeMatrixError(w, r, v, &errMatrix{"https://ntfy.example.com/upABCDEFGHI?up=1", errHTTPBadRequestMatrixPushkeyBaseURLMismatch}))
 	require.Equal(t, 200, w.Result().StatusCode)
 	require.Equal(t, `{"rejected":["https://ntfy.example.com/upABCDEFGHI?up=1"]}`+"\n", w.Body.String())

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,17 +6,19 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"log"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 	"heckel.io/ntfy/auth"
@@ -814,7 +816,7 @@ func TestServer_PublishTooRequests_Defaults(t *testing.T) {
 
 func TestServer_PublishTooRequests_Defaults_ExemptHosts(t *testing.T) {
 	c := newTestConfig(t)
-	c.VisitorRequestExemptIPAddrs = []string{"9.9.9.9"} // see request()
+	c.VisitorRequestExemptIPAddrs = []netip.Prefix{netip.MustParsePrefix("9.9.9.9/32")} // see request()
 	s := newTestServer(t, c)
 	for i := 0; i < 65; i++ { // > 60
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil)

--- a/server/smtp_sender.go
+++ b/server/smtp_sender.go
@@ -32,7 +32,7 @@ func (s *smtpSender) Send(v *visitor, m *message, to string) error {
 		if err != nil {
 			return err
 		}
-		message, err := formatMail(s.config.BaseURL, v.ip, s.config.SMTPSenderFrom, to, m)
+		message, err := formatMail(s.config.BaseURL, v.ip.String(), s.config.SMTPSenderFrom, to, m)
 		if err != nil {
 			return err
 		}

--- a/server/types.go
+++ b/server/types.go
@@ -1,9 +1,11 @@
 package server
 
 import (
-	"heckel.io/ntfy/util"
 	"net/http"
+	"net/netip"
 	"time"
+
+	"heckel.io/ntfy/util"
 )
 
 // List of possible events
@@ -33,7 +35,7 @@ type message struct {
 	Actions    []*action   `json:"actions,omitempty"`
 	Attachment *attachment `json:"attachment,omitempty"`
 	PollID     string      `json:"poll_id,omitempty"`
-	Sender     string      `json:"-"`                  // IP address of uploader, used for rate limiting
+	Sender     netip.Addr  `json:"-"`                  // IP address of uploader, used for rate limiting
 	Encoding   string      `json:"encoding,omitempty"` // empty for raw UTF-8, or "base64" for encoded bytes
 }
 

--- a/server/visitor.go
+++ b/server/visitor.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"errors"
-	"golang.org/x/time/rate"
-	"heckel.io/ntfy/util"
+	"net/netip"
 	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
+	"heckel.io/ntfy/util"
 )
 
 const (
@@ -23,7 +25,7 @@ var (
 type visitor struct {
 	config        *Config
 	messageCache  *messageCache
-	ip            string
+	ip            netip.Addr
 	requests      *rate.Limiter
 	emails        *rate.Limiter
 	subscriptions util.Limiter
@@ -40,7 +42,7 @@ type visitorStats struct {
 	VisitorAttachmentBytesRemaining int64 `json:"visitorAttachmentBytesRemaining"`
 }
 
-func newVisitor(conf *Config, messageCache *messageCache, ip string) *visitor {
+func newVisitor(conf *Config, messageCache *messageCache, ip netip.Addr) *visitor {
 	return &visitor{
 		config:        conf,
 		messageCache:  messageCache,
@@ -115,7 +117,7 @@ func (v *visitor) Stale() bool {
 }
 
 func (v *visitor) Stats() (*visitorStats, error) {
-	attachmentsBytesUsed, err := v.messageCache.AttachmentBytesUsed(v.ip)
+	attachmentsBytesUsed, err := v.messageCache.AttachmentBytesUsed(v.ip.String())
 	if err != nil {
 		return nil, err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net/netip"
 	"os"
 	"regexp"
 	"strconv"
@@ -46,8 +47,8 @@ func Contains[T comparable](haystack []T, needle T) bool {
 	return false
 }
 
-// ContainsContains returns true if any element of haystack .Contains(needle).
-func ContainsContains[T interface{ Contains(U) bool }, U any](haystack []T, needle U) bool {
+// ContainsIP returns true if any one of the of prefixes contains the ip.
+func ContainsIP(haystack []netip.Prefix, needle netip.Addr) bool {
 	for _, s := range haystack {
 		if s.Contains(needle) {
 			return true

--- a/util/util.go
+++ b/util/util.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gabriel-vasile/mimetype"
-	"golang.org/x/term"
 	"io"
 	"math/rand"
 	"os"
@@ -15,6 +13,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gabriel-vasile/mimetype"
+	"golang.org/x/term"
 )
 
 const (
@@ -39,6 +40,16 @@ func FileExists(filename string) bool {
 func Contains[T comparable](haystack []T, needle T) bool {
 	for _, s := range haystack {
 		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsContains returns true if any element of haystack .Contains(needle).
+func ContainsContains[T interface{ Contains(U) bool }, U any](haystack []T, needle U) bool {
+	for _, s := range haystack {
+		if s.Contains(needle) {
 			return true
 		}
 	}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,10 +1,12 @@
 package util
 
 import (
-	"github.com/stretchr/testify/require"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRandomString(t *testing.T) {
@@ -40,6 +42,13 @@ func TestContains(t *testing.T) {
 	s := []int{1, 2}
 	require.True(t, Contains(s, 2))
 	require.False(t, Contains(s, 3))
+}
+
+func TestContainsIP(t *testing.T) {
+	require.True(t, ContainsIP([]netip.Prefix{netip.MustParsePrefix("fd00::/8"), netip.MustParsePrefix("1.1.0.0/16")}, netip.MustParseAddr("1.1.1.1")))
+	require.True(t, ContainsIP([]netip.Prefix{netip.MustParsePrefix("fd00::/8"), netip.MustParsePrefix("1.1.0.0/16")}, netip.MustParseAddr("fd12:1234:5678::9876")))
+	require.False(t, ContainsIP([]netip.Prefix{netip.MustParsePrefix("fd00::/8"), netip.MustParsePrefix("1.1.0.0/16")}, netip.MustParseAddr("1.2.0.1")))
+	require.False(t, ContainsIP([]netip.Prefix{netip.MustParsePrefix("fd00::/8"), netip.MustParsePrefix("1.1.0.0/16")}, netip.MustParseAddr("fc00::1")))
 }
 
 func TestSplitNoEmpty(t *testing.T) {


### PR DESCRIPTION
- Refactor visitor IPs and allow exempting IP Ranges

  Use netip.Addr instead of storing addresses as strings. This requires
  conversions at the database level and in tests, but is more memory
  efficient and efficient to compare; mainly it facilitates the following.
  
  Parse rate limit exemptions as netip.Prefix. This allows storing IP
  ranges in the exemption list. Regular IP addresses (entered explicitly
  or resolved from hostnames) are IPV4/32, denoting a range of just that one
  address.


~~**draft** still need to add tests and fix bugs.~~

However, is the change from string IPs to netip.Addr and netip.Prefix acceptable?

Closes #423
