### PR TITLE
Add ansible-ntfy to Ansible section

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -109,6 +109,19 @@ One of my co-workers uses the following Ansible task to let him know when things
     body: "{{ inventory_hostname }} reseeding complete"
 ```
 
+There's also a dedicated Ansible action plugin (one which runs on the Ansible controller) called
+[ansible-ntfy](https://github.com/jpmens/ansible-ntfy). The following task posts a message
+to ntfy at its default URL (`attrs` and other attributes are optional):
+
+```yml
+- name: "Notify ntfy that we're done"
+  ntfy:
+       msg: "deployment on {{ inventory_hostname }} is complete. 🐄"
+       attrs:
+          tags: [ heavy_check_mark ]
+          priority: 1
+```
+
 ## Watchtower (shoutrrr)
 You can use [shoutrrr](https://github.com/containrrr/shoutrrr) generic webhook support to send 
 [Watchtower](https://github.com/containrrr/watchtower/) notifications to your ntfy topic.


### PR DESCRIPTION
Adds an example of Ansible's ntfy to the documentation.

Addresses: https://github.com/binwiederhier/ntfy/issues/454 