### PR TITLE
Fix bug where GET or HEAD action requests could not be made from the web client

### DIFF
--- a/web/src/components/Notifications.js
+++ b/web/src/components/Notifications.js
@@ -399,7 +399,9 @@ const performHttpAction = async (notification, action) => {
         const response = await fetch(action.url, {
             method: action.method ?? "POST",
             headers: action.headers ?? {},
-            body: action.body ?? ""
+            // This must not null-coalesce to a non nullish value. Otherwise, the fetch API
+            // will reject it for "having a body"
+            body: action.body
         });
         console.log(`[Notifications] HTTP user action response`, response);
         const success = response.status >= 200 && response.status <= 299;


### PR DESCRIPTION
See #468 for details on the bug this fixes.

The cause of this comes down to a subtlety of the `fetch` API. If `body` is anything that is non-nullish, the browser will spit back that a body is not allowed for a GET/HEAD request. The fix is just to remove the null coalesce :)

Closes #468