### PR TITLE
docs: fix link syntax error

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -17,7 +17,7 @@ We support amd64, armv7 and arm64.
 3. Or (optionally) create/edit `~/.config/ntfy/client.yml` (or `/etc/ntfy/client.yml`, see [sample client.yml](https://github.com/binwiederhier/ntfy/blob/main/client/client.yml))
 
 To run the ntfy server, then just run `ntfy serve` (or `systemctl start ntfy` when using the deb/rpm).
-To send messages, use `ntfy publish`. To subscribe to topics, use `ntfy subscribe` (see [subscribing via CLI][subscribe/cli.md]
+To send messages, use `ntfy publish`. To subscribe to topics, use `ntfy subscribe` (see [subscribing via CLI](subscribe/cli.md)
 for details). 
 
 ## Linux binaries


### PR DESCRIPTION
Hello, I found one trivial link syntax error on the [Install page](https://ntfy.sh/docs/install/#general-steps). This PR corrects the link properly.

**Screenshot**
<img width="719" alt="Screenshot 2022-11-08 at 23 16 58" src="https://user-images.githubusercontent.com/1425259/200588177-cbcddc2e-d716-4852-9154-4028aca2fa35.png">
