### PR TITLE
Fix the Kubernetes ConfigMap

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -431,7 +431,7 @@ Configuration is relatively straightforward. As an exmaple, a minimal configurat
     metadata:
       name: ntfy
     data:
-    server.yml: |
+      server.yml: |
         # Template: https://github.com/binwiederhier/ntfy/blob/main/server/server.yml
         base-url: https://ntfy.sh
     ```


### PR DESCRIPTION
Hi 

While migrating from docker (standalone) to Kubernetes, I noticed an indentation error on the config-map (causing a fatal error). 
This "huge" PR is fixing this problem :smile: 

thank you for your amazing project :) 