### PR TITLE
Use prepared statement for bulk writes

### DIFF
--- a/server/message_cache.go
+++ b/server/message_cache.go
@@ -258,12 +258,23 @@ func (c *messageCache) addMessages(ms []*message) error {
 	if c.nop {
 		return nil
 	}
+	if len(ms) == 0 {
+		return nil
+	}
 	start := time.Now()
 	tx, err := c.db.Begin()
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
+	statement, err := tx.Prepare(
+		insertMessageQuery,
+	)
+	if err != nil {
+		return err
+	}
+	defer statement.Close()
+
 	for _, m := range ms {
 		if m.Event != messageEvent {
 			return errUnexpectedMessageType
@@ -291,8 +302,7 @@ func (c *messageCache) addMessages(ms []*message) error {
 		if m.Sender.IsValid() {
 			sender = m.Sender.String()
 		}
-		_, err := tx.Exec(
-			insertMessageQuery,
+		_, err := statement.Exec(
 			m.ID,
 			m.Time,
 			m.Topic,


### PR DESCRIPTION
When executing the same statement multiple times, avoid the overhead of re-parsing the statement for each insert.