### PR TITLE
Added clarification on client.yml configuration

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ We support amd64, armv7 and arm64.
 
 1. Install ntfy using one of the methods described below
 2. Then (optionally) edit `/etc/ntfy/server.yml` for the server (Linux only, see [configuration](config.md) or [sample server.yml](https://github.com/binwiederhier/ntfy/blob/main/server/server.yml))
-3. Or (optionally) create/edit `~/.config/ntfy/client.yml` (or `/etc/ntfy/client.yml`, see [sample client.yml](https://github.com/binwiederhier/ntfy/blob/main/client/client.yml))
+3. Or (optionally) create/edit `~/.config/ntfy/client.yml` (for the non-root user) or `/etc/ntfy/client.yml` (for the root user), see [sample client.yml](https://github.com/binwiederhier/ntfy/blob/main/client/client.yml))
 
 To run the ntfy server, then just run `ntfy serve` (or `systemctl start ntfy` when using the deb/rpm).
 To send messages, use `ntfy publish`. To subscribe to topics, use `ntfy subscribe` (see [subscribing via CLI](subscribe/cli.md)


### PR DESCRIPTION
I didn't understand why the `ntfy publish --debug topic message` command don't choose the default-host I entered in `/etc/ntfy/client.yml`. 
If command is run as root -> config file = `/etc/ntfy/client.yml` 
If command is run as non-root -> config file = `~/.config/ntfy/client.yml` 
I think this is an important precision for users.