### PR TITLE
Fix small issues in the K8s sts documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -371,7 +371,7 @@ unmanned pod.
           containers:
           - name: ntfy
             image: binwiederhier/ntfy
-            args: ["serve", "--cache-file /var/cache/ntfy/cache.db"]
+            args: ["serve", "--cache-file", "/var/cache/ntfy/cache.db"]
             ports:
             - containerPort: 80
               name: http
@@ -379,6 +379,8 @@ unmanned pod.
             - name: config
               mountPath: "/etc/ntfy"
               readOnly: true
+            - name: cache
+              mountPath: "/var/cache/ntfy"
           volumes:
             - name: config
               configMap:


### PR DESCRIPTION
When I was deploying ntfy to my Kubernetes cluster, I noticed two small mistakes in the documentation.

The flag `--cache-file` and its argument need to be passed as two separate arguments; otherwise it gets parsed as a single long flag and results in an "incorrect usage" error.

The pvc needs to be mounted to actually get used.