### PR TITLE
Rough draft of reciever rate limiting for discussion

### DIFF
--- a/server/topic.go
+++ b/server/topic.go
@@ -1,36 +1,64 @@
 package server
 
 import (
-	"heckel.io/ntfy/log"
 	"math/rand"
 	"sync"
+	"time"
+
+	"heckel.io/ntfy/log"
 )
 
 // topic represents a channel to which subscribers can subscribe, and publishers
 // can publish a message
 type topic struct {
 	ID          string
-	subscribers map[int]subscriber
+	subscribers map[int]topicSubscription
+	lastUnsub   topicSubscription
 	mu          sync.Mutex
 }
 
 // subscriber is a function that is called for every new message on a topic
+type topicSubscription struct {
+	f         subscriber
+	v         *visitor
+	unsubTime time.Time
+}
 type subscriber func(v *visitor, msg *message) error
 
 // newTopic creates a new topic
 func newTopic(id string) *topic {
 	return &topic{
 		ID:          id,
-		subscribers: make(map[int]subscriber),
+		subscribers: make(map[int]topicSubscription),
 	}
 }
 
+// need a better name for bill?
+// Returns nil, nil for non-UP topics
+// returns visitor, nil for active UP topics
+// returns nil, err for inactive UP topics
+func (t *topic) getBillee() *visitor {
+	//get a pseudo random visitor???
+	for _, this_subscriber := range t.subscribers {
+		return this_subscriber.v
+	}
+	// what if someone unsubscribed and DOESNT want their sub to count against them anymore, maybe the app server lost sync and will keep on sending stuff
+	// I guess they suffer for unifiedPushSubscriptionDuration?
+
+	// if lastunsub v exists, and the time since it was unsubbed is longer than our limit, it should not exist
+	if t.lastUnsub.v != nil && time.Since(t.lastUnsub.unsubTime) > unifiedPushSubscriptionDuration {
+		t.lastUnsub.v = nil
+	}
+
+	return t.lastUnsub.v
+}
+
 // Subscribe subscribes to this topic
-func (t *topic) Subscribe(s subscriber) int {
+func (t *topic) Subscribe(s subscriber, v *visitor) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	subscriberID := rand.Int()
-	t.subscribers[subscriberID] = s
+	t.subscribers[subscriberID] = topicSubscription{f: s, v: v}
 	return subscriberID
 }
 
@@ -38,6 +66,10 @@ func (t *topic) Subscribe(s subscriber) int {
 func (t *topic) Unsubscribe(id int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if len(t.subscribers) == 1 {
+		t.lastUnsub = t.subscribers[id]
+		t.lastUnsub.unsubTime = time.Now()
+	}
 	delete(t.subscribers, id)
 }
 
@@ -56,7 +88,7 @@ func (t *topic) Publish(v *visitor, m *message) error {
 					if err := s(v, m); err != nil {
 						log.Warn("%s Error forwarding to subscriber", logMessagePrefix(v, m))
 					}
-				}(s)
+				}(s.f)
 			}
 		} else {
 			log.Trace("%s No stream or WebSocket subscribers, not forwarding", logMessagePrefix(v, m))
@@ -73,10 +105,10 @@ func (t *topic) SubscribersCount() int {
 }
 
 // subscribersCopy returns a shallow copy of the subscribers map
-func (t *topic) subscribersCopy() map[int]subscriber {
+func (t *topic) subscribersCopy() map[int]topicSubscription {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	subscribers := make(map[int]subscriber)
+	subscribers := make(map[int]topicSubscription)
 	for k, v := range t.subscribers {
 		subscribers[k] = v
 	}


### PR DESCRIPTION
This is the original proposal from the Matrix room
me:
> My main idea, the ideal solution (as PeterCxy proposed) is to move the cost, for at least UP rate limits, to the receiver instead of the sender.
> 
> There are many ways to do it, but one potential solution (a simple but clean-ish one I could think of):
> 
>  -   Like id: and user:, make up* topics a up: visitor. [1]
>  -  This up: visitor (the UP topic) has large-ish rate limits (to prevent obvious spam/misconfiguration), but doesn't care too much.
>  -  Topic.Subscribe and Topic.Unsubscribe keep track of the most recent visitor to subscribe to a topic, and the time (say prev. 12hrs is valid). [2]
>  -   On Topic.Publish, the message is 'billed' to the most-recent-visitor's rate limit (either ip: or user:), rejected if there is no recent visitor.
>  -   Delete the message if successfully delivered to at least one client. UP topics are unique to each client anyways. [3]
> 
> [1] In which case up* topics have to be reserved explicitly for receiver-based rate limiting. We cannot rely on up=1 because the client doesn't control that.
> [2] If all of this is in-memory: say someone loses their connection, wait 1 hour, ntfy restarts, wait 1 hour, they resubscribe. If there was a notification at T+90 minutes, that notification would be lost, since the topic would show up as 'fresh', and the notification rejected. However, this seems like a fair compromise for the simplicity of avoiding a database.
> [3] Attempt delivering to multiple clients if they are online and subscribed though, for debugging purposes. This is just an extra resource-saving measure and not part of the core plan.
> 
> I can actually help you make it now, though, once we agree on a plan, since this is needed by a clear deadline.

binwiederhier:
> I think I understand this plan. In my own words:
> 
> For topics starting with up*, we keep track of the visitors that are subscribed to a topic in the topic struct.
> 
> When a message is published, we determine the visitor based on the topic name instead of the IP (v := s.visitorByTopic("upABCDEF..")). If there are multiple visitors, we pick the most recent one.
> 
> The rest of the logic remains the same.
> 
> Correct?

me:
> Basically, yes. The goal is to 'bill' that messsage to the most recently subscribed visitor instead of to the sender.
> 
> Additionally, this would require formally defining 'up*' as a special namespace, since messages are "billed" differently.
