### PR TITLE
Elements requiring chown to run non-root Docker

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -287,7 +287,7 @@ services:
     restart: unless-stopped
 ```
 
-If using a non-root user when running the docker version, be sure to chown the server.yml, user.db, and cache.db files to the same uid/gid.
+If using a non-root user when running the docker version, be sure to chown the server.yml, user.db, and cache.db files and attachments directory to the same uid/gid.
 
 Alternatively, you may wish to build a customized Docker image that can be run with fewer command-line arguments and without delivering the configuration file separately.
 ```


### PR DESCRIPTION
We also have to chown the attachments directory otherwise the docker container does not start and crashes. BTW, all that should be automated at the container creation. Because it took me at least an hour to understand that the only way to accomplish that chown command was to first launch the container as root, run the commands, and only then edit docker-compose.yml to add uid/gid. After that I could restart the container and it would now not crash.