### PR TITLE
Draft: user-header authentication

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -8,6 +8,9 @@ import (
 
 // Auther is a generic interface to implement password-based authentication and authorization
 type Auther interface {
+	// PreAuthenticatedUser looks up the user for a given username, and returns a user if one is found.
+	PreAuthenticatedUser(username) (*User, error)
+
 	// Authenticate checks username and password and returns a user if correct. The method
 	// returns in constant-ish time, regardless of whether the user exists or the password is
 	// correct or incorrect.

--- a/auth/auth_sqlite.go
+++ b/auth/auth_sqlite.go
@@ -98,6 +98,12 @@ func NewSQLiteAuth(filename string, defaultRead, defaultWrite bool) (*SQLiteAuth
 	}, nil
 }
 
+// PreAuthenticatedUser looks up a user based on name- no validation of credentials is done!
+func (a *SQLiteAuth) Authenticate(username) (*User, error) {
+	user, err := a.User(username)
+	return user, nil
+}
+
 // Authenticate checks username and password and returns a user if correct. The method
 // returns in constant-ish time, regardless of whether the user exists or the password is
 // correct or incorrect.

--- a/server/config.go
+++ b/server/config.go
@@ -101,6 +101,7 @@ type Config struct {
 	BehindProxy                          bool
 	EnableWeb                            bool
 	Version                              string // injected by App
+	UserHeader                           string
 }
 
 // NewConfig instantiates a default new server config
@@ -146,5 +147,6 @@ func NewConfig() *Config {
 		BehindProxy:                          false,
 		EnableWeb:                            true,
 		Version:                              "",
+		UserHeader:                           "",
 	}
 }


### PR DESCRIPTION
This begins to sketch out a hacky way to implement https://github.com/binwiederhier/ntfy/issues/601.
Not being particularly familiar with go, or the ntfy code base, I haven't tried to compile or run this code.

I'm not particulary comfortable with the interface between `auth` and `server`- unless basic auth support is removed from `auth`, I'd suggest moving code for credential extraction from the request to the `auther`, whether that's using basic auth or a configured header, and select which auther to use during server setup.
