### PR TITLE
Subscriber Billed Topics

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -3,8 +3,9 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"heckel.io/ntfy/log"
 	"net/http"
+
+	"heckel.io/ntfy/log"
 )
 
 // errHTTP is a generic HTTP error for any non-200 HTTP error
@@ -92,5 +93,4 @@ var (
 	errHTTPInternalError                             = &errHTTP{50001, http.StatusInternalServerError, "internal server error", ""}
 	errHTTPInternalErrorInvalidPath                  = &errHTTP{50002, http.StatusInternalServerError, "internal server error: invalid path", ""}
 	errHTTPInternalErrorMissingBaseURL               = &errHTTP{50003, http.StatusInternalServerError, "internal server error: base-url must be be configured for this feature", "https://ntfy.sh/docs/config/"}
-	errHTTPWontStoreMessage                          = &errHTTP{50701, http.StatusInsufficientStorage, "topic is inactive; no device available to recieve message", ""}
 )

--- a/server/errors.go
+++ b/server/errors.go
@@ -92,4 +92,5 @@ var (
 	errHTTPInternalError                             = &errHTTP{50001, http.StatusInternalServerError, "internal server error", ""}
 	errHTTPInternalErrorInvalidPath                  = &errHTTP{50002, http.StatusInternalServerError, "internal server error: invalid path", ""}
 	errHTTPInternalErrorMissingBaseURL               = &errHTTP{50003, http.StatusInternalServerError, "internal server error: base-url must be be configured for this feature", "https://ntfy.sh/docs/config/"}
+	errHTTPWontStoreMessage                          = &errHTTP{50701, http.StatusInsufficientStorage, "topic is inactive; no device available to recieve message", ""}
 )

--- a/server/server.go
+++ b/server/server.go
@@ -1023,7 +1023,7 @@ func (s *Server) handleSubscribeHTTP(w http.ResponseWriter, r *http.Request, v *
 	defer cancel()
 	subscriberIDs := make([]int, 0)
 	for _, t := range topics {
-		subscriberIDs = append(subscriberIDs, t.Subscribe(sub, v.MaybeUserID(), cancel))
+		subscriberIDs = append(subscriberIDs, t.Subscribe(sub, v, cancel))
 	}
 	defer func() {
 		for i, subscriberID := range subscriberIDs {
@@ -1155,7 +1155,7 @@ func (s *Server) handleSubscribeWS(w http.ResponseWriter, r *http.Request, v *vi
 	}
 	subscriberIDs := make([]int, 0)
 	for _, t := range topics {
-		subscriberIDs = append(subscriberIDs, t.Subscribe(sub, v.MaybeUserID(), cancel))
+		subscriberIDs = append(subscriberIDs, t.Subscribe(sub, v, cancel))
 	}
 	defer func() {
 		for i, subscriberID := range subscriberIDs {

--- a/server/server.go
+++ b/server/server.go
@@ -114,13 +114,15 @@ var (
 )
 
 const (
-	firebaseControlTopic     = "~control"                // See Android if changed
-	firebasePollTopic        = "~poll"                   // See iOS if changed
-	emptyMessageBody         = "triggered"               // Used if message body is empty
-	newMessageBody           = "New message"             // Used in poll requests as generic message
-	defaultAttachmentMessage = "You received a file: %s" // Used if message body is empty, and there is an attachment
-	encodingBase64           = "base64"                  // Used mainly for binary UnifiedPush messages
-	jsonBodyBytesLimit       = 16384
+	firebaseControlTopic        = "~control"                // See Android if changed
+	firebasePollTopic           = "~poll"                   // See iOS if changed
+	emptyMessageBody            = "triggered"               // Used if message body is empty
+	newMessageBody              = "New message"             // Used in poll requests as generic message
+	defaultAttachmentMessage    = "You received a file: %s" // Used if message body is empty, and there is an attachment
+	encodingBase64              = "base64"                  // Used mainly for binary UnifiedPush messages
+	jsonBodyBytesLimit          = 16384
+	subscriberBilledTopicPrefix = "up_"
+	subscriberBilledValidity    = 12 * time.Hour
 )
 
 // WebSocket constants

--- a/server/server.go
+++ b/server/server.go
@@ -372,7 +372,6 @@ func (s *Server) handleError(w http.ResponseWriter, r *http.Request, v *visitor,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", s.config.AccessControlAllowOrigin) // CORS, allow cross-origin requests
-	w.Header().Set("TTL", "0")                                                       // if message is not being stored because of an error, tell them
 	w.WriteHeader(httpErr.HTTPCode)
 	io.WriteString(w, httpErr.JSON()+"\n")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1417,7 +1417,7 @@ func (s *Server) execManager() {
 				if ev.IsTrace() {
 					expiryMessage := ""
 					if subs == 0 {
-						expiryTime := time.Until(t.lastVisitorExpires)
+						expiryTime := time.Until(t.vRateExpires)
 						expiryMessage = ", expires in " + expiryTime.String()
 					}
 					ev.Trace("- topic %s: %d subscribers%s", t.ID, subs, expiryMessage)

--- a/server/server.go
+++ b/server/server.go
@@ -1420,8 +1420,12 @@ func (s *Server) execManager() {
 			defer s.mu.Unlock()
 			for _, t := range s.topics {
 				subs := t.SubscribersCount()
-				expiryTime := time.Until(t.lastVisitorExpires)
-				log.Tag(tagManager).Trace("- topic %s: %d subscribers, expires in %s", t.ID, subs, expiryTime)
+				expiryMessage := ""
+				if subs == 0 {
+					expiryTime := time.Until(t.lastVisitorExpires)
+					expiryMessage = ", expires in " + expiryTime.String()
+				}
+				log.Tag(tagManager).Trace("- topic %s: %d subscribers%s", t.ID, subs, expiryMessage)
 				msgs, exists := messageCounts[t.ID]
 				if t.Stale() && (!exists || msgs == 0) {
 					log.Tag(tagManager).Trace("Deleting empty topic %s", t.ID)

--- a/server/server.go
+++ b/server/server.go
@@ -694,9 +694,6 @@ func (s *Server) handlePublish(w http.ResponseWriter, r *http.Request, v *visito
 		return err
 	}
 
-	w.Header().Set("TTL", strconv.FormatInt(m.Expires-m.Time, 10)) // return how long a message will be stored for
-
-	// using m.Time, not time.Now() so the value isn't negative if the request is processed at a second boundary
 	return s.writeJSON(w, m)
 }
 

--- a/server/topic.go
+++ b/server/topic.go
@@ -58,6 +58,8 @@ func (t *topic) Subscribe(s subscriber, visitor *visitor, cancel func(), subscri
 }
 
 func (t *topic) Stale() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	// if Time is initialized (not the zero value) and the expiry time has passed
 	if !t.lastVisitorExpires.IsZero() && t.lastVisitorExpires.Before(time.Now()) {
 		t.lastVisitor = nil
@@ -66,6 +68,8 @@ func (t *topic) Stale() bool {
 }
 
 func (t *topic) Billee() *visitor {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return t.lastVisitor
 }
 

--- a/server/util.go
+++ b/server/util.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"heckel.io/ntfy/log"
-	"heckel.io/ntfy/util"
 	"io"
 	"net/http"
 	"net/netip"
 	"strings"
+
+	"heckel.io/ntfy/log"
+	"heckel.io/ntfy/util"
 )
 
 func readBoolParam(r *http.Request, defaultValue bool, names ...string) bool {
@@ -15,6 +16,17 @@ func readBoolParam(r *http.Request, defaultValue bool, names ...string) bool {
 		return defaultValue
 	}
 	return value == "1" || value == "yes" || value == "true"
+}
+
+func readCommaSeperatedParam(r *http.Request, names ...string) (params []string) {
+	paramStr := readParam(r, names...)
+	if paramStr != "" {
+		params = make([]string, 0)
+		for _, s := range util.SplitNoEmpty(paramStr, ",") {
+			params = append(params, strings.TrimSpace(s))
+		}
+	}
+	return params
 }
 
 func readParam(r *http.Request, names ...string) string {
@@ -33,6 +45,13 @@ func readHeaderParam(r *http.Request, names ...string) string {
 		}
 	}
 	return ""
+}
+
+func readHeaderParamValues(r *http.Request, names ...string) (values []string) {
+	for _, name := range names {
+		values = append(values, r.Header.Values(name)...)
+	}
+	return
 }
 
 func readQueryParam(r *http.Request, names ...string) string {


### PR DESCRIPTION
I am going with bill-to-last-visitor-for-12-hrs even though it doesn't [allow users to unsubscribe](https://github.com/binwiederhier/ntfy/pull/584#discussion_r1083381767) because it is the simplest to explain. It's much easier to document and explain _if you subscribe to a `up_` topic, you are responsible for whatever is sent there for the next 12 hrs, so keep it secret_, than anything else I could come up with.

The only other simple-for-the-user options would be: 
1. _You can only subscribe to 30 UP topics in a day. Each UP topic can receive 100 messages / day._ However, that requires keeping track of all those states and adds significant complexity to the code.
2. Bill in `sub := func(v *visitor, msg *message) error {`, so only messages you actually receive count against you. However, that allows spamming the cache with messages that no one is billed for, on the sending side.


I'll add tests and rebase it and stuff if you're good with this general implementation.
