### PR TITLE
Make email publishing work, when access-control is enabled

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -2582,6 +2582,11 @@ format is:
 ntfy-$topic@ntfy.sh
 ```
 
+If [access control](config.md#access-control) is enabled, and the target topic does not support anonymous writes, e-mail publishing won't work without providing an authorized access token. That will change the format of the e-mail's recipient address to
+```
+ntfy-$topic+$token@ntfy.sh
+```
+
 As of today, e-mail publishing only supports adding a [message title](#message-title) (the e-mail subject). Tags, priority,
 delay and other features are not supported (yet). Here's an example that will publish a message with the 
 title `You've Got Mail` to topic `sometopic` (see [ntfy.sh/sometopic](https://ntfy.sh/sometopic)):

--- a/server/smtp_server.go
+++ b/server/smtp_server.go
@@ -65,6 +65,7 @@ type smtpSession struct {
 	backend *smtpBackend
 	conn    *smtp.Conn
 	topic   string
+	token   string
 	mu      sync.Mutex
 }
 
@@ -81,6 +82,7 @@ func (s *smtpSession) Mail(from string, opts *smtp.MailOptions) error {
 func (s *smtpSession) Rcpt(to string) error {
 	logem(s.conn).Field("smtp_rcpt_to", to).Debug("RCPT TO: %s", to)
 	return s.withFailCount(func() error {
+		token := ""
 		conf := s.backend.config
 		addressList, err := mail.ParseAddressList(to)
 		if err != nil {
@@ -92,18 +94,27 @@ func (s *smtpSession) Rcpt(to string) error {
 		if !strings.HasSuffix(to, "@"+conf.SMTPServerDomain) {
 			return errInvalidDomain
 		}
+		// remove @ntfy.sh from end of email
 		to = strings.TrimSuffix(to, "@"+conf.SMTPServerDomain)
 		if conf.SMTPServerAddrPrefix != "" {
 			if !strings.HasPrefix(to, conf.SMTPServerAddrPrefix) {
 				return errInvalidAddress
 			}
+			// remove ntfy- from beginning of email
 			to = strings.TrimPrefix(to, conf.SMTPServerAddrPrefix)
+		}
+		// if email contains token, split topic and token
+		if strings.Contains(to, "+") {
+			parts := strings.Split(to, "+")
+			to = parts[0]
+			token = parts[1]
 		}
 		if !topicRegex.MatchString(to) {
 			return errInvalidTopic
 		}
 		s.mu.Lock()
 		s.topic = to
+		s.token = token
 		s.mu.Unlock()
 		return nil
 	})
@@ -176,6 +187,9 @@ func (s *smtpSession) publishMessage(m *message) error {
 	}
 	if m.Title != "" {
 		req.Header.Set("Title", m.Title)
+	}
+	if s.token != "" {
+		req.Header.Add("Authorization", "Bearer "+s.token)
 	}
 	rr := httptest.NewRecorder()
 	s.backend.handler(rr, req)


### PR DESCRIPTION
This will fix #420, by allowing emails in the format `${prefix}-${topic}+${token}@${host}`, so the user can pass a token with write-permissions to the defined topic.

A container image to test it with is available via `ghcr.io/tamcore/ntfy:v2.0.1@sha256:e6616f3531f9960da1f0ea918feb73faa8ffa0794a58d0d606eb131f911a7650`

---
## Tests
### **Without token**
```
root@ubuntu:/# cat << EOC | nc -N ntfy.ntfy.svc.cluster.local 2525
> EHLO example.com
> MAIL FROM: phil@example.com
> RCPT TO: ntfy-mytopic@ntfy.ntfy.svc.cluster.local
> DATA
> Subject: Email for you
> Content-Type: text/plain; charset="UTF-8"
>
> Hello from 🇩🇪
> .
> EOC
220 ntfy.ntfy.svc.cluster.local ESMTP Service Ready
250-Hello example.com
250-PIPELINING
250-8BITMIME
250-ENHANCEDSTATUSCODES
250-CHUNKING
250-AUTH PLAIN
250 SIZE 1048576
250 2.0.0 Roger, accepting mail from <phil@example.com>
250 2.0.0 I'll make sure <ntfy-mytopic@ntfy.ntfy.svc.cluster.local> gets this
354 2.0.0 Go ahead. End your data with <CR><LF>.<CR><LF>
554 5.0.0 Error: transaction failed, blame it on the weather: error: {"code":40301,"http":403,"error":"forbidden","link":"https://ntfy.sh/docs/publish/#authentication"}
```

### **With invalid token**
```
root@ubuntu:/# cat << EOC | nc -N ntfy.ntfy.svc.cluster.local 2525
> EHLO example.com
> MAIL FROM: phil@example.com
> RCPT TO: ntfy-mytopic+tk_invalidtoken@ntfy.ntfy.svc.cluster.local
> DATA
> Subject: Email for you
> Content-Type: text/plain; charset="UTF-8"
>
> Hello from 🇩🇪
> .
> EOC
220 ntfy.ntfy.svc.cluster.local ESMTP Service Ready
250-Hello example.com
250-PIPELINING
250-8BITMIME
250-ENHANCEDSTATUSCODES
250-CHUNKING
250-AUTH PLAIN
250 SIZE 1048576
250 2.0.0 Roger, accepting mail from <phil@example.com>
250 2.0.0 I'll make sure <ntfy-mytopic+tk_invalidtoken@ntfy.ntfy.svc.cluster.local> gets this
354 2.0.0 Go ahead. End your data with <CR><LF>.<CR><LF>
554 5.0.0 Error: transaction failed, blame it on the weather: error: {"code":40101,"http":401,"error":"unauthorized","link":"https://ntfy.sh/docs/publish/#authentication"}
```

### **With valid token**
```
root@ubuntu:/# cat << EOC | nc -N ntfy.ntfy.svc.cluster.local 2525
> EHLO example.com
> MAIL FROM: phil@example.com
> RCPT TO: ntfy-mytopic+tk_JhbsnoMrgy2FcfHeofv97Pi5uXaZZ@ntfy.ntfy.svc.cluster.local
> DATA
> Subject: Email for you
> Content-Type: text/plain; charset="UTF-8"
>
> Hello from 🇩🇪
> .
> EOC
220 ntfy.ntfy.svc.cluster.local ESMTP Service Ready
250-Hello example.com
250-PIPELINING
250-8BITMIME
250-ENHANCEDSTATUSCODES
250-CHUNKING
250-AUTH PLAIN
250 SIZE 1048576
250 2.0.0 Roger, accepting mail from <phil@example.com>
250 2.0.0 I'll make sure <ntfy-mytopic+tk_JhbsnoMrgy2FcfHeofv97Pi5uXaZZ@ntfy.ntfy.svc.cluster.local> gets this
354 2.0.0 Go ahead. End your data with <CR><LF>.<CR><LF>
250 2.0.0 OK: queued
```