### PR TITLE
Add nlog-ntfy integration to docs

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -112,6 +112,7 @@ and uptime of third party servers, so use of each server is **at your own discre
 - [ntfy-wrapper](https://github.com/vict0rsch/ntfy-wrapper) - Wrapper around ntfy (Python)
 - [nodebb-plugin-ntfy](https://github.com/NodeBB/nodebb-plugin-ntfy) - Push notifications for NodeBB forums
 - [n8n-ntfy](https://github.com/raghavanand98/n8n-ntfy.sh) - n8n community node that lets you use ntfy in your workflows
+- [nlog-ntfy](https://github.com/MichelMichels/nlog-ntfy) - Send NLog messages over ntfy (C# / .NET / NLog)
 
 ## Blog + forum posts
 


### PR DESCRIPTION
I wrote an integration for the C# .NET logging framework NLog. It provides an Ntfy target and layoutrenderer as an extensions for NLog.

See the [repository](https://github.com/MichelMichels/nlog-ntfy) for more information.