### PR TITLE
Remove health check from dockerfile & document health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,5 @@ MAINTAINER Philipp C. Heckel <philipp.heckel@gmail.com>
 
 COPY ntfy /usr/bin
 
-HEALTHCHECK --interval=60s --timeout=10s CMD wget -q --tries=1 http://localhost/v1/health -O - | grep -Eo '"healthy"\s*:\s*true' || exit 1
-
 EXPOSE 80/tcp
 ENTRYPOINT ["ntfy"]

--- a/docs/config.md
+++ b/docs/config.md
@@ -1067,6 +1067,16 @@ and [here](https://easyengine.io/tutorials/nginx/block-wp-login-php-bruteforce-a
     maxretry = 10
     ```
 
+## Health checks
+A preliminary health check API endpoint is exposed at `"/v1/health"`. The endpoint returns a `json` response in the format shown below.
+If a non-200 HTTP status code is returned or if the returned `health` field is `false` the ntfy service should be considered as unhealthy.
+
+```json
+{"health":true}
+```
+
+See [Installalation/Docker](install.md#docker) for an example of how this could be used in a `docker-compose` environment.
+
 ## Logging & debugging
 By default, ntfy logs to the console (stderr), with an `info` log level, and in a human-readable text format.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -266,7 +266,7 @@ docker run \
   serve
 ```
 
-Using docker-compose with non-root user:
+Using docker-compose with non-root user and healthchecks enabled:
 ```yaml
 version: "2.1"
 
@@ -284,6 +284,12 @@ services:
       - /etc/ntfy:/etc/ntfy
     ports:
       - 80:80
+    healthcheck: # optional: remember to adapt the host:port to your environment
+        test: ["CMD-SHELL", "wget -q --tries=1 http://localhost:80/v1/health -O - | grep -Eo '\"healthy\"\\s*:\\s*true' || exit 1"]
+        interval: 60s
+        timeout: 10s
+        retries: 3
+        start_period: 40s
     restart: unless-stopped
 ```
 


### PR DESCRIPTION
This fixes the health check issue described in #635.

It reverts the health check added to the dockerfile in #555. In addition documentation on how to use the health check API endpoint have been added.