### PR TITLE
Added informative labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM alpine
-MAINTAINER Philipp C. Heckel <philipp.heckel@gmail.com>
+
+LABEL org.opencontainers.image.authors="philipp.heckel@gmail.com"
+LABEL org.opencontainers.image.url="https://ntfy.sh/"
+LABEL org.opencontainers.image.documentation="https://docs.ntfy.sh/"
+LABEL org.opencontainers.image.source="https://github.com/binwiederhier/ntfy"
+LABEL org.opencontainers.image.vendor="Philipp C. Heckel"
+LABEL org.opencontainers.image.licenses="Apache-2.0, GPL-2.0"
+LABEL org.opencontainers.image.title="ntfy"
+LABEL org.opencontainers.image.description="Send push notifications to your phone or desktop using PUT/POST"
 
 COPY ntfy /usr/bin
 


### PR DESCRIPTION
Hi,

I have removed the deprecated `Maintainer` statement and replaced it with the [OpenContainers Author Annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys).

While I was doing that, I have added the other labels as well.

These labels are useful if using the `docker inspect` command.

Kind regards

Sharknoon