### PR TITLE
Fix publish command preferring default user instead of token auth

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -171,7 +171,7 @@ func execPublish(c *cli.Context) error {
 			fmt.Fprintf(c.App.ErrWriter, "\r%s\r", strings.Repeat(" ", 20))
 		}
 		options = append(options, client.WithBasicAuth(user, pass))
-	} else if conf.DefaultUser != "" && conf.DefaultPassword != nil {
+	} else if token == "" && conf.DefaultUser != "" && conf.DefaultPassword != nil {
 		options = append(options, client.WithBasicAuth(conf.DefaultUser, *conf.DefaultPassword))
 	}
 	if pid > 0 {


### PR DESCRIPTION
As reported in #650, the `publish` command seems to prefer `default-user` and `default-password` config keys if they are defined in `client.yml`. 

This PR aims to fix this problem, checking if the token isn't passed as a flag to the `ntfy pub` command before attempting to use the credentials stored in the client config file.