### PR TITLE
remove redundant ?poll=1 query param

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -126,9 +126,6 @@ func execSubscribe(c *cli.Context) error {
 		}
 		options = append(options, client.WithBasicAuth(user, pass))
 	}
-	if poll {
-		options = append(options, client.WithPoll())
-	}
 	if scheduled {
 		options = append(options, client.WithScheduled())
 	}


### PR DESCRIPTION
Previous:
```
GET /mytopic/json?poll=1&poll=1 HTTP/1.1
Host: localhost:8080
User-Agent: Go-http-client/1.1
Accept-Encoding: gzip
```

Now:
```
GET /mytopic/json?poll=1 HTTP/1.1
Host: localhost:8080
User-Agent: Go-http-client/1.1
Accept-Encoding: gzip
```