### PR TITLE
Allow newer python when building docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,25 +96,28 @@ build-deps-ubuntu:
 docs: docs-deps docs-build
 
 docs-build: .PHONY
-	@if ! /bin/echo -e "import sys\nif sys.version_info < (3,8):\n exit(1)" | python3; then \
-	  if which python3.8; then \
-	  	echo "python3.8 $(shell which mkdocs) build"; \
-	    python3.8 $(shell which mkdocs) build; \
-	  else \
-	    echo "ERROR: Python version too low. mkdocs-material needs >= 3.8"; \
-	    exit 1; \
-	  fi; \
-	else \
-	  echo "mkdocs build"; \
-	  mkdocs build; \
-	fi
+	@if ! SUFFIX=$$(tools/get-best-python-for-docs-build.sh); then \
+		echo "ERROR: could not find a recent version of Python. mkdocs needs >= 3.8"; \
+		exit 1; \
+	fi; \
+	echo "python$$SUFFIX $$(which mkdocs) build"; \
+	"python$$SUFFIX" $$(which mkdocs) build
 
 docs-deps: .PHONY
-	pip3 install -r requirements.txt
+	@if ! SUFFIX=$$(tools/get-best-python-for-docs-build.sh); then \
+		echo "ERROR: could not find a recent version of Python. mkdocs needs >= 3.8"; \
+		exit 1; \
+	fi; \
+	echo "pip$$SUFFIX install -r requirements.txt"; \
+	"pip$$SUFFIX" install -r requirements.txt
 
 docs-deps-update: .PHONY
-	pip3 install -r requirements.txt --upgrade
-
+	@if ! SUFFIX=$$(tools/get-best-python-for-docs-build.sh); then \
+		echo "ERROR: could not find a recent version of Python. mkdocs needs >= 3.8"; \
+		exit 1; \
+	fi; \
+	echo "pip$$SUFFIX install -r requirements.txt --upgrade"; \
+	"pip$$SUFFIX" install -r requirements.txt --upgrade
 
 # Web app
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 MAKEFLAGS := --jobs=1
+
 VERSION := $(shell git describe --tag)
 COMMIT := $(shell git rev-parse --short HEAD)
+
+PY_BIN := $(shell tools/get-python-bin.sh python)
+PIP_BIN := $(shell tools/get-python-bin.sh pip)
 
 .PHONY:
 
@@ -96,16 +100,13 @@ build-deps-ubuntu:
 docs: docs-deps docs-build
 
 docs-build: .PHONY
-	PY=$$(tools/get-python-bin.sh python) && MKDOCS=$$(which mkdocs) && \
-	$$PY $$MKDOCS build
+	PY=$$(which $(PY_BIN)) && MKDOCS=$$(which mkdocs) && $$PY $$MKDOCS build
 
 docs-deps: .PHONY
-	PIP=$$(tools/get-python-bin.sh pip) && \
-	$$PIP install -r requirements.txt
+	PIP=$$(which $(PIP_BIN)) && $$PIP install -r requirements.txt
 
 docs-deps-update: .PHONY
-	PIP=$$(tools/get-python-bin.sh pip) && \
-	$$PIP install -r requirements.txt --upgrade
+	PIP=$$(which $(PIP_BIN)) && $$PIP install -r requirements.txt --upgrade
 
 # Web app
 

--- a/Makefile
+++ b/Makefile
@@ -96,28 +96,16 @@ build-deps-ubuntu:
 docs: docs-deps docs-build
 
 docs-build: .PHONY
-	@if ! SUFFIX=$$(tools/get-best-python-for-docs-build.sh); then \
-		echo "ERROR: could not find a recent version of Python. mkdocs needs >= 3.8"; \
-		exit 1; \
-	fi; \
-	echo "python$$SUFFIX $$(which mkdocs) build"; \
-	"python$$SUFFIX" $$(which mkdocs) build
+	PY=$$(tools/get-python-bin.sh python) && MKDOCS=$$(which mkdocs) && \
+	$$PY $$MKDOCS build
 
 docs-deps: .PHONY
-	@if ! SUFFIX=$$(tools/get-best-python-for-docs-build.sh); then \
-		echo "ERROR: could not find a recent version of Python. mkdocs needs >= 3.8"; \
-		exit 1; \
-	fi; \
-	echo "pip$$SUFFIX install -r requirements.txt"; \
-	"pip$$SUFFIX" install -r requirements.txt
+	PIP=$$(tools/get-python-bin.sh pip) && \
+	$$PIP install -r requirements.txt
 
 docs-deps-update: .PHONY
-	@if ! SUFFIX=$$(tools/get-best-python-for-docs-build.sh); then \
-		echo "ERROR: could not find a recent version of Python. mkdocs needs >= 3.8"; \
-		exit 1; \
-	fi; \
-	echo "pip$$SUFFIX install -r requirements.txt --upgrade"; \
-	"pip$$SUFFIX" install -r requirements.txt --upgrade
+	PIP=$$(tools/get-python-bin.sh pip) && \
+	$$PIP install -r requirements.txt --upgrade
 
 # Web app
 

--- a/tools/get-best-python-for-docs-build.sh
+++ b/tools/get-best-python-for-docs-build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This script prints the version suffix of the most suitable version of Python
+# for building docs that's installed in this system.
+#
+# Caller can safely append this suffix to `python` or `pip` and expect the
+# binary to exist.
+#
+# If no usable version of Python is available, this script will exit with a
+# non-zero code.
+
+set -e
+
+# if `python3` is >= 3.8 and `pip3` is available, use that
+if echo -e "import sys\nif sys.version_info < (3,8):\n exit(1)" | python3 && \
+which pip3 1>/dev/null 2>&1; then
+    echo "3"
+    exit 0
+fi
+
+# check `python3.N` from newest to oldest
+CANDIDATE_SUFFIXES=("3.11" "3.10" "3.9" "3.8")
+for SUFFIX in ${CANDIDATE_SUFFIXES[@]}; do
+    # if both `python3.N` and `pip3.N` are available, use that
+    if which "python$SUFFIX" 1>/dev/null 2>&1 && \
+    which "pip$SUFFIX" 1>/dev/null 2>&1; then
+        echo "$SUFFIX"
+        exit 0
+    fi
+done
+
+# none found
+exit 1

--- a/tools/get-python-bin.sh
+++ b/tools/get-python-bin.sh
@@ -29,13 +29,14 @@ which pip3 1>/dev/null 2>&1; then
     exit 0
 fi
 
-# check `python3.N` from newest to oldest
-CANDIDATE_SUFFIXES=("3.11" "3.10" "3.9" "3.8")
-for SUFFIX in ${CANDIDATE_SUFFIXES[@]}; do
+# list all available `python3.N`, then use the newest that passes checks
+# compgen is bash-specific, but we asked for bash in shebang so it's fine
+MINOR_VERSION_CANDIDATES=$(compgen -c | grep -P '^python3\.[0-9]+$' | sed 's/python3\.//' | awk 'int($NF) >= 8' | sort -nr)
+for MINOR in ${MINOR_VERSION_CANDIDATES[@]}; do
     # if both `python3.N` and `pip3.N` are available, use that
-    if which "python$SUFFIX" 1>/dev/null 2>&1 && \
-    which "pip$SUFFIX" 1>/dev/null 2>&1; then
-        echo "${BIN_PREFIX}${SUFFIX}"
+    if which "python3.${MINOR}" 1>/dev/null 2>&1 && \
+    which "pip3.${MINOR}" 1>/dev/null 2>&1; then
+        echo "${BIN_PREFIX}3.${MINOR}"
         exit 0
     fi
 done

--- a/tools/get-python-bin.sh
+++ b/tools/get-python-bin.sh
@@ -1,20 +1,31 @@
 #!/usr/bin/env bash
 
-# This script prints the version suffix of the most suitable version of Python
-# for building docs that's installed in this system.
+# Synopsis:
+# - get-python-bin.sh python
+# - get-python-bin.sh pip
 #
-# Caller can safely append this suffix to `python` or `pip` and expect the
-# binary to exist.
+# This script selects the most suitable `python` / `pip` binary available
+# for building docs that's installed in this system.
 #
 # If no usable version of Python is available, this script will exit with a
 # non-zero code.
 
 set -e
 
+case "$1" in
+    "python" | "pip")
+        BIN_PREFIX="$1"
+        ;;
+    *)
+        echo "Incorrect usage" >&2
+        exit 1
+        ;;
+esac
+
 # if `python3` is >= 3.8 and `pip3` is available, use that
 if echo -e "import sys\nif sys.version_info < (3,8):\n exit(1)" | python3 && \
 which pip3 1>/dev/null 2>&1; then
-    echo "3"
+    echo "${BIN_PREFIX}3"
     exit 0
 fi
 
@@ -24,10 +35,11 @@ for SUFFIX in ${CANDIDATE_SUFFIXES[@]}; do
     # if both `python3.N` and `pip3.N` are available, use that
     if which "python$SUFFIX" 1>/dev/null 2>&1 && \
     which "pip$SUFFIX" 1>/dev/null 2>&1; then
-        echo "$SUFFIX"
+        echo "${BIN_PREFIX}${SUFFIX}"
         exit 0
     fi
 done
 
 # none found
-exit 1
+echo "No suitable version of Python found" >&2
+exit 2


### PR DESCRIPTION
Previously in `Makefile`, there are provisions to use `python3.8` if `python3` is not new enough. However it doesn't check for versions newer than 3.8, which could be problematic if the user has `python3.6` and `python3.9`, but `python3` points to `python3.6`. This is a frequent occurrence on RHEL systems.

This change also makes sure that the version of `pip` called matches the version of `python` used. Now I'm not that familiar with Python, so I cannot say for certain whether this is strictly necessary. But I cannot imagine there to be any downsides with doing this.