### PR TITLE
Fix false positive in ContainsAll function

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/time/rate"
 	"io"
 	"math/rand"
 	"net/netip"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/gabriel-vasile/mimetype"
 	"golang.org/x/term"
@@ -67,15 +68,12 @@ func ContainsIP(haystack []netip.Prefix, needle netip.Addr) bool {
 
 // ContainsAll returns true if all needles are contained in haystack
 func ContainsAll[T comparable](haystack []T, needles []T) bool {
-	matches := 0
-	for _, s := range haystack {
-		for _, needle := range needles {
-			if s == needle {
-				matches++
-			}
+	for _, needle := range needles {
+		if !Contains(haystack, needle) {
+			return false
 		}
 	}
-	return matches == len(needles)
+	return true
 }
 
 // SplitNoEmpty splits a string using strings.Split, but filters out empty strings

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"errors"
-	"golang.org/x/time/rate"
 	"io"
 	"net/netip"
 	"os"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +48,11 @@ func TestContains(t *testing.T) {
 	s := []int{1, 2}
 	require.True(t, Contains(s, 2))
 	require.False(t, Contains(s, 3))
+}
+
+func TestContainsAll(t *testing.T) {
+	require.True(t, ContainsAll([]int{1, 2, 3}, []int{2, 3}))
+	require.False(t, ContainsAll([]int{1, 1}, []int{1, 2}))
 }
 
 func TestContainsIP(t *testing.T) {


### PR DESCRIPTION
As the `ContainsAll` is working with a match counter, it could return a false positive when the `haystack` slice contains duplicate elements.

This can be checked with the included testing scenario, with `haystack = [1, 1]` and `needles = [1, 2]`. Iterating over the haystack to check for items to be present in needles will increase the match counter to 2, even if `2` is not present in the first slice.