### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,28 +6,19 @@ jobs:
     steps:
       -
         name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.19.x'
       -
         name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: './web/package-lock.json'
       -
         name: Checkout code
-        uses: actions/checkout@v2
-      -
-        name: Cache Go and npm modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/.npm
-            web/node_modules
-          key: ${{ runner.os }}-ntfy-${{ hashFiles('go.sum', 'web/package.lock') }}
-          restore-keys: ${{ runner.os }}-ntfy-
+        uses: actions/checkout@v3
       -
         name: Install dependencies
         run: make build-deps-ubuntu

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout code
+        uses: actions/checkout@v3
+      -
         name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -16,9 +19,6 @@ jobs:
           node-version: '18'
           cache: 'npm'
           cache-dependency-path: './web/package-lock.json'
-      -
-        name: Checkout code
-        uses: actions/checkout@v3
       -
         name: Install dependencies
         run: make build-deps-ubuntu

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           cd build/ntfy-docs.github.io
           git config user.name "GitHub Actions Bot"
-          git config user.email "<>"          
+          git config user.email "<actions@github.com>"          
           git add docs/
           git commit -m "Updated docs"
           git push origin main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout code
+        uses: actions/checkout@v3
+      -
         name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -19,9 +22,6 @@ jobs:
           node-version: '18'
           cache: 'npm'
           cache-dependency-path: './web/package-lock.json'
-      -
-        name: Checkout code
-        uses: actions/checkout@v3
       -
         name: Docker login
         uses: docker/login-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,28 +9,19 @@ jobs:
     steps:
       -
         name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.19.x'
       -
         name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: './web/package-lock.json'
       -
         name: Checkout code
-        uses: actions/checkout@v2
-      -
-        name: Cache Go and npm modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/.npm
-            web/node_modules
-          key: ${{ runner.os }}-ntfy-${{ hashFiles('go.sum', 'web/package.lock') }}
-          restore-keys: ${{ runner.os }}-ntfy-
+        uses: actions/checkout@v3
       -
         name: Docker login
         uses: docker/login-action@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,28 +6,19 @@ jobs:
     steps:
       -
         name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.19.x'
       -
         name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: './web/package-lock.json'
       -
         name: Checkout code
-        uses: actions/checkout@v2
-      -
-        name: Cache Go and npm modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/.npm
-            web/node_modules
-          key: ${{ runner.os }}-ntfy-${{ hashFiles('go.sum', 'web/package.lock') }}
-          restore-keys: ${{ runner.os }}-ntfy-
+        uses: actions/checkout@v3
       -
         name: Install dependencies
         run: make build-deps-ubuntu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout code
+        uses: actions/checkout@v3
+      -
         name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -16,9 +19,6 @@ jobs:
           node-version: '18'
           cache: 'npm'
           cache-dependency-path: './web/package-lock.json'
-      -
-        name: Checkout code
-        uses: actions/checkout@v3
       -
         name: Install dependencies
         run: make build-deps-ubuntu


### PR DESCRIPTION
- Use the newest versions to solve the deprecation warning
- Remove the cache step as the newest go and node actions have built-in caching
- Add the official actions@github.com email address