### PR TITLE
Add a way to use Docker for building everything

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+dist
+*/node_modules
+Dockerfile*

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,0 +1,53 @@
+FROM golang:1.19-bullseye as builder
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+
+RUN apt-get update
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash
+RUN apt-get install -y \
+    build-essential \
+    nodejs \
+    python3-pip
+
+WORKDIR /app
+ADD Makefile .
+
+# docs
+ADD ./requirements.txt .
+RUN make docs-deps
+ADD ./mkdocs.yml .
+ADD ./docs ./docs
+RUN make docs-build
+ 
+# web
+ADD ./web/package.json ./web/package-lock.json ./web/
+RUN make web-deps
+ADD ./web ./web
+RUN make web-build
+
+# cli & server
+ADD go.mod go.sum main.go ./
+ADD ./client ./client
+ADD ./cmd ./cmd
+ADD ./log ./log
+ADD ./server ./server
+ADD ./user ./user
+ADD ./util ./util
+RUN make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server
+
+FROM alpine
+
+LABEL org.opencontainers.image.authors="philipp.heckel@gmail.com"
+LABEL org.opencontainers.image.url="https://ntfy.sh/"
+LABEL org.opencontainers.image.documentation="https://docs.ntfy.sh/"
+LABEL org.opencontainers.image.source="https://github.com/binwiederhier/ntfy"
+LABEL org.opencontainers.image.vendor="Philipp C. Heckel"
+LABEL org.opencontainers.image.licenses="Apache-2.0, GPL-2.0"
+LABEL org.opencontainers.image.title="ntfy"
+LABEL org.opencontainers.image.description="Send push notifications to your phone or desktop using PUT/POST"
+
+COPY --from=builder /app/dist/ntfy_linux_server/ntfy /usr/bin/ntfy
+
+EXPOSE 80/tcp
+ENTRYPOINT ["ntfy"]

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,16 @@ help:
 	@echo "  make cli-darwin-server          - Build client & server (no GoReleaser, current arch, macOS)"
 	@echo "  make cli-client                 - Build client only (no GoReleaser, current arch, Linux/macOS/Windows)"
 	@echo
+	@echo "Build dev Docker:"
+	@echo "  make docker-dev                 - Build client & server for current architecture using Docker only"
+	@echo
 	@echo "Build web app:"
 	@echo "  make web                        - Build the web app"
 	@echo "  make web-deps                   - Install web app dependencies (npm install the universe)"
 	@echo "  make web-build                  - Actually build the web app"
-	@echo "  make web-format                 - Run prettier on the web app
-	@echo "  make web-format-check           - Run prettier on the web app, but don't change anything
+	@echo "  make web-lint                   - Run eslint on the web app"
+	@echo "  make web-format                 - Run prettier on the web app"
+	@echo "  make web-format-check           - Run prettier on the web app, but don't change anything"
 	@echo
 	@echo "Build documentation:"
 	@echo "  make docs                       - Build the documentation"
@@ -81,6 +85,15 @@ build: web docs cli
 
 update: web-deps-update cli-deps-update docs-deps-update
 	docker pull alpine
+
+docker-dev:
+	docker build \
+		--file ./Dockerfile-build \
+		--tag binwiederhier/ntfy:$(VERSION) \
+		--tag binwiederhier/ntfy:dev \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg COMMIT=$(COMMIT) \
+		./
 
 # Ubuntu-specific
 

--- a/Makefile
+++ b/Makefile
@@ -85,13 +85,13 @@ update: web-deps-update cli-deps-update docs-deps-update
 # Ubuntu-specific
 
 build-deps-ubuntu:
-	sudo apt update
-	sudo apt install -y \
+	sudo apt-get update
+	sudo apt-get install -y \
 		curl \
 		gcc-aarch64-linux-gnu \
 		gcc-arm-linux-gnueabi \
 		jq
-	which pip3 || sudo apt install -y python3-pip
+	which pip3 || sudo apt-get install -y python3-pip
 
 # Documentation
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -163,6 +163,15 @@ $ make release-snapshot
 
 During development, you may want to be more picky and build only certain things. Here are a few examples.
 
+### Build a Docker image only for Linux
+
+This is useful to test the final build with web app, docs, and server without any dependencies locally
+
+``` shell
+$ make docker-dev
+$ docker run --rm -p 80:80 binwiederhier/ntfy:dev serve
+```
+
 ### Build the ntfy binary
 To build only the `ntfy` binary **without the web app or documentation**, use the `make cli-...` targets:
 


### PR DESCRIPTION
Add a way to use Docker for building everything

I’d like to test #751 on my own instance, but installing all the build
dependencies on my server isn’t ideal - having this script in the repo
would make it possible to simply point my compose file to the git repo
and have it build the Linux binary itself.

Note that it uses a somewhat “inefficient” builder step, i.e. not
combining steps together to reduce layers, as it uses a multi-stage
build to have a lean final image. This makes it easier to re-build if
something needs to change, as the cache is used more optimally.

For example, if only some go files change, most of the build is already
cached and only the go step gets re-run.

The more “efficient” builder step would look like this, but would have
to build the docs, web app and go CLI for any change in any file:

```Dockerfile
FROM golang:1.19-bullseye as builder

RUN apt-get update && \
    curl -fsSL https://deb.nodesource.com/setup_18.x | bash && \
    apt-get install -y \
    build-essential \
    nodejs \
    python3-pip

WORKDIR /app
ADD . .

RUN make web docs cli-linux-server
```