### PR TITLE
Fix account sync race condition

### DIFF
--- a/web/src/components/hooks.js
+++ b/web/src/components/hooks.js
@@ -47,6 +47,13 @@ export const useConnectionListeners = (account, subscriptions, users) => {
 
       const handleMessage = async (subscriptionId, message) => {
         const subscription = await subscriptionManager.get(subscriptionId);
+
+        // Race condition: sometimes the subscription is already unsubscribed from account
+        // sync before the message is handled
+        if (!subscription) {
+          return;
+        }
+
         if (subscription.internal) {
           await handleInternalMessage(message);
         } else {


### PR DESCRIPTION
Sometimes the subscription is already unsubscribed due to account sync before a received message is handled, this ignores the message if so.