### PR TITLE
*: python pip in debian bookworm/testing needs venv

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -8,7 +8,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash
 RUN apt-get install -y \
     build-essential \
     nodejs \
-    python3-pip
+    python3-pip \
+    python3-venv
 
 WORKDIR /app
 ADD Makefile .

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,9 @@ build-deps-ubuntu:
 
 docs: docs-deps docs-build
 
-docs-build: .PHONY
-	@if ! /bin/echo -e "import sys\nif sys.version_info < (3,8):\n exit(1)" | python3; then \
+docs-build: venv .PHONY
+	@. venv/bin/activate && \
+	if ! /bin/echo -e "import sys\nif sys.version_info < (3,8):\n exit(1)" | python3; then \
 	  if which python3.8; then \
 	  	echo "python3.8 $(shell which mkdocs) build"; \
 	    python3.8 $(shell which mkdocs) build; \
@@ -124,10 +125,15 @@ docs-build: .PHONY
 	  mkdocs build; \
 	fi
 
-docs-deps: .PHONY
+venv:
+	python3 -m venv ./venv
+
+docs-deps: venv .PHONY
+	. venv/bin/activate && \
 	pip3 install -r requirements.txt
 
-docs-deps-update: .PHONY
+docs-deps-update: venv .PHONY
+	. venv/bin/activate && \
 	pip3 install -r requirements.txt --upgrade
 
 


### PR DESCRIPTION
When testing this build using the upcoming debian bookworm/testing, the python pip v3.11 fails to install requirements that may clobber the host install packages. It prints out that venv must be used.

This change works fine on the current debian bullseye, and will continue to work once folks switch to the upcoming debian bookworm release.