### PR TITLE
Update Docker-Compose Version in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -277,7 +277,7 @@ docker run \
 
 Using docker-compose with non-root user and healthchecks enabled:
 ```yaml
-version: "2.1"
+version: "2.3"
 
 services:
   ntfy:


### PR DESCRIPTION
According to https://docs.docker.com/compose/compose-file/compose-file-v2/#healthcheck, 'start_period' is only supported since version 2.3