### PR TITLE
Fix: refresh web push pref on standalone change

### DIFF
--- a/web/src/app/Notifier.js
+++ b/web/src/app/Notifier.js
@@ -128,7 +128,8 @@ class Notifier {
   }
 
   iosSupportedButInstallRequired() {
-    return this.pushSupported() && "standalone" in window.navigator && window.navigator.standalone === false;
+    // no PushManager when not installed, but it _is_ supported.
+    return config.enable_web_push && "serviceWorker" in navigator && window.navigator.standalone === false;
   }
 }
 

--- a/web/src/app/utils.js
+++ b/web/src/app/utils.js
@@ -263,16 +263,3 @@ export const urlB64ToUint8Array = (base64String) => {
   }
   return outputArray;
 };
-
-export const isLaunchedPWA = () => {
-  if (window.matchMedia("(display-mode: standalone)").matches) {
-    return true;
-  }
-
-  // iOS
-  if (window.navigator.standalone === true) {
-    return true;
-  }
-
-  return false;
-};

--- a/web/src/components/Preferences.jsx
+++ b/web/src/components/Preferences.jsx
@@ -36,7 +36,7 @@ import { Info } from "@mui/icons-material";
 import { useOutletContext } from "react-router-dom";
 import theme from "./theme";
 import userManager from "../app/UserManager";
-import { isLaunchedPWA, playSound, shuffle, sounds, validUrl } from "../app/utils";
+import { playSound, shuffle, sounds, validUrl } from "../app/utils";
 import session from "../app/Session";
 import routes from "./routes";
 import accountApi, { Permission, Role } from "../app/AccountApi";
@@ -49,6 +49,7 @@ import { ReserveAddDialog, ReserveDeleteDialog, ReserveEditDialog } from "./Rese
 import { UnauthorizedError } from "../app/errors";
 import { subscribeTopic } from "./SubscribeDialog";
 import notifier from "../app/Notifier";
+import { useIsLaunchedPWA } from "./hooks";
 
 const maybeUpdateAccountSettings = async (payload) => {
   if (!session.exists()) {
@@ -77,6 +78,9 @@ const Preferences = () => (
 
 const Notifications = () => {
   const { t } = useTranslation();
+
+  const isLaunchedPWA = useIsLaunchedPWA();
+
   return (
     <Card sx={{ p: 3 }} aria-label={t("prefs_notifications_title")}>
       <Typography variant="h5" sx={{ marginBottom: 2 }}>
@@ -86,7 +90,7 @@ const Notifications = () => {
         <Sound />
         <MinPriority />
         <DeleteAfter />
-        {!isLaunchedPWA() && notifier.pushPossible() && <WebPushEnabled />}
+        {!isLaunchedPWA && notifier.pushPossible() && <WebPushEnabled />}
       </PrefGroup>
     </Card>
   );


### PR DESCRIPTION
Move to a common reactive hook instead of relying on a function call.