### PR TITLE
Make action bar match theme colour when run as PWA

### DIFF
--- a/web/src/components/ActionBar.jsx
+++ b/web/src/components/ActionBar.jsx
@@ -19,11 +19,14 @@ import Navigation from "./Navigation";
 import accountApi from "../app/AccountApi";
 import PopupMenu from "./PopupMenu";
 import { SubscriptionPopup } from "./SubscriptionPopup";
+import { useIsLaunchedPWA } from "./hooks";
 
 const ActionBar = (props) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const location = useLocation();
+  const isLaunchedPWA = useIsLaunchedPWA();
+
   let title = "ntfy";
   if (props.selected) {
     title = topicDisplayName(props.selected);
@@ -32,6 +35,22 @@ const ActionBar = (props) => {
   } else if (location.pathname === routes.account) {
     title = t("action_bar_account");
   }
+
+  const getActionBarBackground = () => {
+    if (isLaunchedPWA) {
+      return "#317f6f";
+    }
+
+    switch (theme.palette.mode) {
+      case "dark":
+        return "linear-gradient(150deg, #203631 0%, #2a6e60 100%)";
+
+      case "light":
+      default:
+        return "linear-gradient(150deg, #338574 0%, #56bda8 100%)";
+    }
+  };
+
   return (
     <AppBar
       position="fixed"
@@ -44,10 +63,7 @@ const ActionBar = (props) => {
       <Toolbar
         sx={{
           pr: "24px",
-          background:
-            theme.palette.mode === "light"
-              ? "linear-gradient(150deg, #338574 0%, #56bda8 100%)"
-              : "linear-gradient(150deg, #203631 0%, #2a6e60 100%)",
+          background: getActionBarBackground(),
         }}
       >
         <IconButton

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -132,7 +132,7 @@ const NavList = (props) => {
   return (
     <>
       <Toolbar sx={{ display: { xs: "none", sm: "block" } }} />
-      <List component="nav" sx={{ paddingTop: alertVisible ? "0" : "" }}>
+      <List component="nav" sx={{ paddingTop: { xs: 0, sm: alertVisible ? 0 : "" } }}>
         {showNotificationPermissionRequired && <NotificationPermissionRequired refreshPermissions={refreshPermissions} />}
         {showNotificationPermissionDenied && <NotificationPermissionDeniedAlert />}
         {showNotificationBrowserNotSupportedBox && <NotificationBrowserNotSupportedAlert />}


### PR DESCRIPTION
## Chrome

|Before|After|
| --- | --- |
|  <img width="1504" alt="CleanShot 2023-06-29 at 00 23 15@2x" src="https://github.com/binwiederhier/ntfy/assets/132819643/c1859287-688d-4b66-a759-32de00184464"> |  <img width="1504" alt="CleanShot 2023-06-29 at 00 23 25@2x" src="https://github.com/binwiederhier/ntfy/assets/132819643/c47a0572-2e6d-4e3b-a19c-3695f9551320"> |
| <img width="1504" alt="CleanShot 2023-06-29 at 00 23 09@2x" src="https://github.com/binwiederhier/ntfy/assets/132819643/2034d7d8-fb66-4050-8a70-04606a6d83cb"> | <img width="1504" alt="CleanShot 2023-06-29 at 00 22 41@2x" src="https://github.com/binwiederhier/ntfy/assets/132819643/92bbee13-e781-42c2-8392-f2b1fec8a5f3"> |

## iOS

|Before|After|
|---|---|
| ![IMG_2921](https://github.com/binwiederhier/ntfy/assets/132819643/76a1eebc-19c9-4ff3-a9ab-6d2ae6239cd6) | ![IMG_2925](https://github.com/binwiederhier/ntfy/assets/132819643/d9ab4118-84aa-4f4c-a729-4e4f0bcc1b9d) |
| ![IMG_2924](https://github.com/binwiederhier/ntfy/assets/132819643/ab2b1d02-4272-420a-b911-c0b826c3568c) | ![IMG_2926](https://github.com/binwiederhier/ntfy/assets/132819643/b6a607ee-3681-4efd-a7cf-89214b09c23d) |

## Dark mode sidebar fix

|Before|After|
|---|---|
| <img width="612" alt="CleanShot 2023-06-29 at 00 23 55@2x" src="https://github.com/binwiederhier/ntfy/assets/132819643/295a127a-3124-463f-82c2-6a1f1511b5d2"> |  <img width="612" alt="CleanShot 2023-06-29 at 00 24 00@2x" src="https://github.com/binwiederhier/ntfy/assets/132819643/c672542b-3c5f-4693-8c7b-00d051e0362f"> |

