### PR TITLE
Web app: add markdown publish

### DIFF
--- a/web/public/static/langs/en.json
+++ b/web/public/static/langs/en.json
@@ -160,6 +160,7 @@
   "publish_dialog_button_cancel_sending": "Cancel sending",
   "publish_dialog_button_cancel": "Cancel",
   "publish_dialog_button_send": "Send",
+  "publish_dialog_checkbox_markdown": "Format as Markdown",
   "publish_dialog_checkbox_publish_another": "Publish another",
   "publish_dialog_attached_file_title": "Attached file:",
   "publish_dialog_attached_file_filename_placeholder": "Attachment filename",

--- a/web/src/components/PublishDialog.jsx
+++ b/web/src/components/PublishDialog.jsx
@@ -61,6 +61,7 @@ const PublishDialog = (props) => {
   const [call, setCall] = useState("");
   const [delay, setDelay] = useState("");
   const [publishAnother, setPublishAnother] = useState(false);
+  const [markdownEnabled, setMarkdownEnabled] = useState(false);
 
   const [showTopicUrl, setShowTopicUrl] = useState("");
   const [showClickUrl, setShowClickUrl] = useState(false);
@@ -148,6 +149,10 @@ const PublishDialog = (props) => {
     if (attachFile && message.trim()) {
       url.searchParams.append("message", message.replaceAll("\n", "\\n").trim());
     }
+    if (markdownEnabled) {
+      url.searchParams.append("markdown", "true");
+    }
+
     const body = attachFile || message;
     try {
       const user = await userManager.get(baseUrl);
@@ -352,6 +357,20 @@ const PublishDialog = (props) => {
             inputProps={{
               "aria-label": t("publish_dialog_message_label"),
             }}
+          />
+          <FormControlLabel
+            label={t("publish_dialog_checkbox_markdown")}
+            sx={{ marginRight: 2 }}
+            control={
+              <Checkbox
+                size="small"
+                checked={markdownEnabled}
+                onChange={(ev) => setMarkdownEnabled(ev.target.checked)}
+                inputProps={{
+                  "aria-label": t("publish_dialog_checkbox_markdown"),
+                }}
+              />
+            }
           />
           <div style={{ display: "flex" }}>
             <EmojiPicker anchorEl={emojiPickerAnchorEl} onEmojiPick={handleEmojiPick} onClose={handleEmojiClose} />


### PR DESCRIPTION
Partially implements 	#310

---

Add client-side markdown support. This can later be automatically used for messages with a markdown content type, but currently relies on the user flipping on a setting.

| Light Mode  | Dark Mode  |
| ----------- | ---------- |
| ![][light1] | ![][dark1] |
| ![][light2] | ![][dark2] |


[light1]: https://github.com/binwiederhier/ntfy/assets/10807310/e2a3e040-3662-411f-8a7e-ce4b86166b3d
[light2]: https://github.com/binwiederhier/ntfy/assets/10807310/44d7ec5e-8be5-4e30-a7f8-3810b9ca453a
[dark1]: https://github.com/binwiederhier/ntfy/assets/10807310/2e9d8880-13c7-4fbc-a09d-d6d27f5a92e6
[dark2]: https://github.com/binwiederhier/ntfy/assets/10807310/e7978892-12ae-4d44-a20a-01e50c98de6a
