### PR TITLE
Add new integration ansible-role-ntfy-alertmanager

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -125,6 +125,7 @@ I've added a ⭐ to projects or posts that have a significant following, or had 
 - [systemd-ntfy-poweronoff](https://github.com/stendler/systemd-ntfy-poweronoff) -  Systemd services to send notifications on system startup and shutdown (Go)
 - [msgdrop](https://github.com/jbrubake/msgdrop) - Send and receive encrypted messages (Bash)
 - [vigilant](https://github.com/VerifiedJoseph/vigilant) - Monitor RSS/ATOM and JSON feeds, and send push notifications on new entries (PHP)
+- [ansible-role-ntfy-alertmanager](https://github.com/bleetube/ansible-role-ntfy-alertmanager) - Ansible role to install xenrox/ntfy-alertmanager
 
 ## Blog + forum posts
 


### PR DESCRIPTION
I also wrote a [ansible-role-ntfy](https://github.com/bleetube/ansible-role-ntfy) a few months ago, but I noticed there is a much better role for installing ntfy on the list already.