### PR TITLE
fix(web-push): re-init i18n on each sw message

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM golang:1.19-bullseye as builder
+FROM golang:1.20-bullseye as builder
 
 ARG VERSION=dev
 ARG COMMIT=unknown

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -7,8 +7,7 @@ import { clientsClaim } from "workbox-core";
 import { dbAsync } from "../src/app/db";
 
 import { toNotificationParams, icon, badge } from "../src/app/notificationUtils";
-
-import i18n from "../src/app/i18n";
+import initI18n from "../src/app/i18n";
 
 /**
  * General docs for service workers and PWAs:
@@ -67,8 +66,10 @@ const handlePushMessage = async (data) => {
  * Handle a received web push subscription expiring.
  */
 const handlePushSubscriptionExpiring = async (data) => {
-  await self.registration.showNotification(i18n.t("web_push_subscription_expiring_title"), {
-    body: i18n.t("web_push_subscription_expiring_body"),
+  const t = await initI18n();
+
+  await self.registration.showNotification(t("web_push_subscription_expiring_title"), {
+    body: t("web_push_subscription_expiring_body"),
     icon,
     data,
     badge,
@@ -80,8 +81,10 @@ const handlePushSubscriptionExpiring = async (data) => {
  * permission can be revoked by the browser.
  */
 const handlePushUnknown = async (data) => {
-  await self.registration.showNotification(i18n.t("web_push_unknown_notification_title"), {
-    body: i18n.t("web_push_unknown_notification_body"),
+  const t = await initI18n();
+
+  await self.registration.showNotification(t("web_push_unknown_notification_title"), {
+    body: t("web_push_unknown_notification_body"),
     icon,
     data,
     badge,
@@ -107,6 +110,8 @@ const handlePush = async (data) => {
  * This is also called when the user clicks on an action button.
  */
 const handleClick = async (event) => {
+  const t = await initI18n();
+
   const clients = await self.clients.matchAll({ type: "window" });
 
   const rootUrl = new URL(self.location.origin);
@@ -147,7 +152,7 @@ const handleClick = async (event) => {
           }
         } catch (e) {
           console.error("[ServiceWorker] Error performing http action", e);
-          self.registration.showNotification(`${i18n.t("notifications_actions_failed_notification")}: ${action.label} (${action.action})`, {
+          self.registration.showNotification(`${t("notifications_actions_failed_notification")}: ${action.label} (${action.action})`, {
             body: e.message,
             icon,
             badge,

--- a/web/src/app/i18n.js
+++ b/web/src/app/i18n.js
@@ -1,4 +1,4 @@
-import i18n from "i18next";
+import i18next from "i18next";
 import Backend from "i18next-http-backend";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
@@ -11,19 +11,20 @@ import { initReactI18next } from "react-i18next";
 // See example project here:
 // https://github.com/i18next/react-i18next/tree/master/example/react
 
-i18n
-  .use(Backend)
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    fallbackLng: "en",
-    debug: true,
-    interpolation: {
-      escapeValue: false, // not needed for react as it escapes by default
-    },
-    backend: {
-      loadPath: "/static/langs/{{lng}}.json",
-    },
-  });
+const initI18n = () =>
+  i18next
+    .use(Backend)
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+      fallbackLng: "en",
+      debug: true,
+      interpolation: {
+        escapeValue: false, // not needed for react as it escapes by default
+      },
+      backend: {
+        loadPath: "/static/langs/{{lng}}.json",
+      },
+    });
 
-export default i18n;
+export default initI18n;

--- a/web/src/components/App.jsx
+++ b/web/src/components/App.jsx
@@ -20,9 +20,11 @@ import Messaging from "./Messaging";
 import Login from "./Login";
 import Signup from "./Signup";
 import Account from "./Account";
-import "../app/i18n"; // Translations!
+import initI18n from "../app/i18n"; // Translations!
 import prefs, { THEME } from "../app/Prefs";
 import RTLCacheProvider from "./RTLCacheProvider";
+
+initI18n();
 
 export const AccountContext = createContext(null);
 


### PR DESCRIPTION
It looks like the context that Safari runs the service worker in does not have the global i18n initialisation. This changes the push handler to get a new i18n TFunction when handling each message. 

Before:

![iOS screenshot with a notification showing i18n key instead of actual text](https://github.com/binwiederhier/ntfy/assets/10807310/484df628-5c42-44df-b561-498e905ecbd4)

After:

![iOS screenshot with a notification showing actual translated text](https://github.com/binwiederhier/ntfy/assets/10807310/a52d628a-806c-4f8a-b7a0-f81ec6ffbec7)
