### PR TITLE
Tweak httpd config to use less resources

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,14 @@ Here are a few working sample configs:
     attachment-cache-dir: "/var/cache/ntfy/attachments"
     ```
 
+=== "server.yml (behind proxy, with cache + attachments)"
+    ``` yaml
+    base-url: "http://ntfy.example.com"
+    listen-http: ":2586"
+    cache-file: "/var/cache/ntfy/cache.db"
+    attachment-cache-dir: "/var/cache/ntfy/attachments"
+    ```
+
 === "server.yml (ntfy.sh config)"
     ``` yaml
     # All the things: Behind a proxy, Firebase, cache, attachments, 

--- a/docs/config.md
+++ b/docs/config.md
@@ -658,14 +658,13 @@ or the root domain:
 
         # Higher than the max message size of 4096 bytes
         LimitRequestBody 102400
-
-        # Enable mod_rewrite (requires "a2enmod rewrite")
-        RewriteEngine on
         
         # Redirect HTTP to HTTPS, but only for GET topic addresses, since we want 
-        # it to work with curl without the annoying https:// prefix 
-        RewriteCond %{REQUEST_METHOD} GET
-        RewriteRule ^/([-_A-Za-z0-9]{0,64})$ https://%{SERVER_NAME}/$1 [R,L]
+        # it to work with curl without the annoying https:// prefix (requires "a2enmod alias")
+        <If "%{REQUEST_METHOD} == 'GET'">
+            RedirectMatch permanent "^/([-_A-Za-z0-9]{0,64})$" "https://%{SERVER_NAME}/$1"
+        </If>
+
     </VirtualHost>
     
     <VirtualHost *:443>
@@ -685,9 +684,6 @@ or the root domain:
 
         # Higher than the max message size of 4096 bytes 
         LimitRequestBody 102400
-
-        # Enable mod_rewrite (requires "a2enmod rewrite")
-        RewriteEngine on
 	
     </VirtualHost>
     ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -649,8 +649,8 @@ or the root domain:
     <VirtualHost *:80>
         ServerName ntfy.sh
 
-        # Proxy connections to ntfy (requires "a2enmod proxy")
-        ProxyPass / http://127.0.0.1:2586/
+        # Proxy connections to ntfy (requires "a2enmod proxy proxy_http")
+        ProxyPass / http://127.0.0.1:2586/ upgrade=websocket
         ProxyPassReverse / http://127.0.0.1:2586/
 
         SetEnv proxy-nokeepalive 1
@@ -661,11 +661,6 @@ or the root domain:
 
         # Enable mod_rewrite (requires "a2enmod rewrite")
         RewriteEngine on
-
-        # WebSockets support (requires "a2enmod rewrite proxy_wstunnel")
-        RewriteCond %{HTTP:Upgrade} websocket [NC]
-        RewriteCond %{HTTP:Connection} upgrade [NC]
-        RewriteRule ^/?(.*) "ws://127.0.0.1:2586/$1" [P,L]
         
         # Redirect HTTP to HTTPS, but only for GET topic addresses, since we want 
         # it to work with curl without the annoying https:// prefix 
@@ -681,8 +676,8 @@ or the root domain:
         SSLCertificateKeyFile /etc/letsencrypt/live/ntfy.sh/privkey.pem
         Include /etc/letsencrypt/options-ssl-apache.conf
 
-        # Proxy connections to ntfy (requires "a2enmod proxy")
-        ProxyPass / http://127.0.0.1:2586/
+        # Proxy connections to ntfy (requires "a2enmod proxy proxy_http")
+        ProxyPass / http://127.0.0.1:2586/ upgrade=websocket
         ProxyPassReverse / http://127.0.0.1:2586/
 
         SetEnv proxy-nokeepalive 1
@@ -693,11 +688,7 @@ or the root domain:
 
         # Enable mod_rewrite (requires "a2enmod rewrite")
         RewriteEngine on
-
-        # WebSockets support (requires "a2enmod rewrite proxy_wstunnel")
-        RewriteCond %{HTTP:Upgrade} websocket [NC]
-        RewriteCond %{HTTP:Connection} upgrade [NC]
-        RewriteRule ^/?(.*) "ws://127.0.0.1:2586/$1" [P,L] 
+	
     </VirtualHost>
     ```
 

--- a/server/server.yml
+++ b/server/server.yml
@@ -342,6 +342,10 @@
 #      - "field -> level" to match any value, e.g. "time_taken_ms -> debug"
 #   Warning: Using log-level-overrides has a performance penalty. Only use it for temporary debugging.
 #
+# Check your permissions:
+#   If you are running ntfy with systemd, make sure this log file is owned by the
+#   ntfy user and group by running: chown ntfy.ntfy <filename>.
+#
 # Example (good for production):
 #   log-level: info
 #   log-format: json


### PR DESCRIPTION
Many thanks for writing this great piece of software and making it open-source! Being able to self-host `ntfy` really goes a long way towards removing one of the weak links in the Matrix ecosystem, which is the reliance on a central push server that can easily get blocked in certain parts of the world.

Just a couple of tweaks mostly to the `httpd` configurations to substitute the deprecated `mod_proxy_wstunnel`, and use more efficient alternatives to `mod_rewrite` mainly for the benefit of constrained environments.