### PR TITLE
Ignore Cloudflare Priority header

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -161,11 +161,6 @@ func ParsePriority(priority string) (int, error) {
 	case "5", "max", "urgent":
 		return 5, nil
 	default:
-		// Ignore new HTTP Priority header (see https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-priority)
-		// Cloudflare adds this to requests when forwarding to the backend (ntfy), so we just ignore it.
-		if strings.HasPrefix(p, "u=") {
-			return 3, nil
-		}
 		return 0, errInvalidPriority
 	}
 }


### PR DESCRIPTION
# Refine handling of HTTP Priority header

Part of: #351, #353, #461, ...

This PR improves the handling of the new HTTP Priority header (RFC 9218) commonly affecting ntfy instances running behind Cloudflare.


## Changes:
- Now if the received PUT/POST request contains the mentioned header simply ignores it and continues searching for another header or query parameter
- This PR reverts some changes in 95bd876

A working instance with this fix can be tested [Here](https://ntfy.gusdleon.com/)
😀
