### PR TITLE
Expose total subscribers and topics in the /v1/stats api - 885

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,8 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/crypto/bcrypt"
-	"heckel.io/ntfy/user"
 	"io"
 	"math/rand"
 	"net/http"
@@ -21,6 +19,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	"heckel.io/ntfy/user"
 
 	"github.com/SherClockHolmes/webpush-go"
 	"github.com/stretchr/testify/require"
@@ -2501,7 +2502,7 @@ func TestServer_MessageHistoryAndStatsEndpoint(t *testing.T) {
 
 	response := request(t, s, "GET", "/v1/stats", "", nil)
 	require.Equal(t, 200, response.Code)
-	require.Equal(t, `{"messages":5,"messages_rate":0}`+"\n", response.Body.String())
+	require.Equal(t, `{"messages":5,"messages_rate":0,"total_topics":1,"total_subscriptions":0}`+"\n", response.Body.String())
 
 	// Run manager and see message history update
 	s.execManager()
@@ -2509,7 +2510,7 @@ func TestServer_MessageHistoryAndStatsEndpoint(t *testing.T) {
 
 	response = request(t, s, "GET", "/v1/stats", "", nil)
 	require.Equal(t, 200, response.Code)
-	require.Equal(t, `{"messages":5,"messages_rate":2.5}`+"\n", response.Body.String()) // 5 messages in 2 seconds = 2.5 messages per second
+	require.Equal(t, `{"messages":5,"messages_rate":2.5,"total_topics":1,"total_subscriptions":0}`+"\n", response.Body.String()) // 5 messages in 2 seconds = 2.5 messages per second
 
 	// Publish some more messages
 	for i := 0; i < 10; i++ {
@@ -2521,7 +2522,7 @@ func TestServer_MessageHistoryAndStatsEndpoint(t *testing.T) {
 
 	response = request(t, s, "GET", "/v1/stats", "", nil)
 	require.Equal(t, 200, response.Code)
-	require.Equal(t, `{"messages":15,"messages_rate":2.5}`+"\n", response.Body.String()) // Rate did not update yet
+	require.Equal(t, `{"messages":15,"messages_rate":2.5,"total_topics":1,"total_subscriptions":0}`+"\n", response.Body.String()) // Rate did not update yet
 
 	// Run manager and see message history update
 	s.execManager()
@@ -2529,7 +2530,7 @@ func TestServer_MessageHistoryAndStatsEndpoint(t *testing.T) {
 
 	response = request(t, s, "GET", "/v1/stats", "", nil)
 	require.Equal(t, 200, response.Code)
-	require.Equal(t, `{"messages":15,"messages_rate":3.75}`+"\n", response.Body.String()) // 15 messages in 4 seconds = 3.75 messages per second
+	require.Equal(t, `{"messages":15,"messages_rate":3.75,"total_topics":1,"total_subscriptions":0}`+"\n", response.Body.String()) // 15 messages in 4 seconds = 3.75 messages per second
 }
 
 func TestServer_MessageHistoryMaxSize(t *testing.T) {

--- a/server/types.go
+++ b/server/types.go
@@ -244,8 +244,10 @@ type apiHealthResponse struct {
 }
 
 type apiStatsResponse struct {
-	Messages     int64   `json:"messages"`
-	MessagesRate float64 `json:"messages_rate"` // Average number of messages per second
+	Messages           int64   `json:"messages"`
+	MessagesRate       float64 `json:"messages_rate"` // Average number of messages per second
+	TotalTopics        int64   `json:"total_topics"`
+	TotalSubscriptions int64   `json:"total_subscriptions"`
 }
 
 type apiUserAddRequest struct {


### PR DESCRIPTION
# Overview

I added the total subscription and topic count to the stats API

# Proof of Performance
I build a dev container using `make docker-dev`. Running it, I can hit the stats API to get the bellow response: 
![Screenshot 2023-09-17 at 11 08 37 AM](https://github.com/binwiederhier/ntfy/assets/26232349/3319696f-2507-4dba-8382-5e5100e519e9)

# Issue

https://github.com/binwiederhier/ntfy/issues/885