### PR TITLE
fix(i18n): correct usage of language str having underline

### DIFF
--- a/web/src/app/utils.js
+++ b/web/src/app/utils.js
@@ -130,14 +130,20 @@ export const hashCode = (s) => {
   return hash;
 };
 
+/**
+ * convert `i18n.language` style str (e.g.: `en_US`) to kebab-case (e.g.: `en-US`),
+ * which is expected by `<html lang>` and `Intl.DateTimeFormat`
+ */
+export const getKebabCaseLangStr = (language) => language.replace(/_/g, '-');
+
 export const formatShortDateTime = (timestamp, language) =>
-  new Intl.DateTimeFormat(language, {
+  new Intl.DateTimeFormat(getKebabCaseLangStr(language), {
     dateStyle: "short",
     timeStyle: "short",
   }).format(new Date(timestamp * 1000));
 
 export const formatShortDate = (timestamp, language) =>
-  new Intl.DateTimeFormat(language, { dateStyle: "short" }).format(new Date(timestamp * 1000));
+  new Intl.DateTimeFormat(getKebabCaseLangStr(language), { dateStyle: "short" }).format(new Date(timestamp * 1000));
 
 export const formatBytes = (bytes, decimals = 2) => {
   if (bytes === 0) return "0 bytes";

--- a/web/src/components/App.jsx
+++ b/web/src/components/App.jsx
@@ -11,7 +11,7 @@ import ActionBar from "./ActionBar";
 import Preferences from "./Preferences";
 import subscriptionManager from "../app/SubscriptionManager";
 import userManager from "../app/UserManager";
-import { expandUrl } from "../app/utils";
+import { expandUrl, getKebabCaseLangStr } from "../app/utils";
 import ErrorBoundary from "./ErrorBoundary";
 import routes from "./routes";
 import { useAccountListener, useBackgroundProcesses, useConnectionListeners, useWebPushTopics } from "./hooks";
@@ -56,7 +56,7 @@ const App = () => {
   );
 
   useEffect(() => {
-    document.documentElement.setAttribute("lang", i18n.language);
+    document.documentElement.setAttribute("lang", getKebabCaseLangStr(i18n.language));
     document.dir = languageDir;
   }, [i18n.language, languageDir]);
 


### PR DESCRIPTION
## Goal

Fix the JS exception in web app when user select a language which **name contains an underline** (e.g., `zh_Hans`).

**Exception Stack**

```plaintext
RangeError: Incorrect locale information provided
  at formatShortDateTime (https://.../src/app/utils.js?t=1697702760936:3:140)
  at NotificationItem (https://.../src/components/Notifications.jsx:15:229)
  at renderWithHooks (https://.../node_modules/react-dom/cjs/react-dom.development.js:17:16305)
  at error (https://.../node_modules/react-dom/cjs/react-dom.development.js:12:20074)
  at pushTreeId (https://.../node_modules/react-dom/cjs/react-dom.development.js:15:21587)
  at beginWork$1 (https://.../node_modules/react-dom/cjs/react-dom.development.js:13:27426)
  at setCurrentFiber (https://.../node_modules/react-dom/cjs/react-dom.development.js:11:26557)
  at workLoopSync (https://.../node_modules/react-dom/cjs/react-dom.development.js:4:26466)
  at renderRootSync (https://.../node_modules/react-dom/cjs/react-dom.development.js:6:26434)
```

## Reporduce

1. Open the web app
2. Subscribe to a topic having **at least one notification**.
3. Switch to setting page and set the language to 简体中文 `zh_Hans` (or another one which **has a underline** in its name)
4. Refresh the web page

## Changes

1. Before calling [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), replace `_` to `-` in `language`
5. (nice to have :smile:) Before setting `lang` attribute of `<html>`, replace `_` to `-` in `language`