### PR TITLE
Fix broken badge image links in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ ntfy lets you **send push notifications to your phone or desktop via scripts fro
 or POST requests. I use it to notify myself when scripts fail, or long-running commands complete.
 
 ## Step 1: Get the app
-<a href="https://play.google.com/store/apps/details?id=io.heckel.ntfy"><img src="../../static/img/badge-googleplay.png"></a>
-<a href="https://f-droid.org/en/packages/io.heckel.ntfy/"><img src="../../static/img/badge-fdroid.png"></a>
-<a href="https://apps.apple.com/us/app/ntfy/id1625396347"><img src="../../static/img/badge-appstore.png"></a>
+<a href="https://play.google.com/store/apps/details?id=io.heckel.ntfy"><img src="static/img/badge-googleplay.png"></a>
+<a href="https://f-droid.org/en/packages/io.heckel.ntfy/"><img src="static/img/badge-fdroid.png"></a>
+<a href="https://apps.apple.com/us/app/ntfy/id1625396347"><img src="static/img/badge-appstore.png"></a>
 
 To [receive notifications on your phone](subscribe/phone.md), install the app, either via Google Play or F-Droid.
 Once installed, open it and subscribe to a topic of your choosing. Topics don't have to explicitly be created, so just


### PR DESCRIPTION
T.: `/docs/` uses incorrect relative paths for the app store badges currently ('t worked on docs.ntfy.sh cause there `/docs/` 's `/`, but on GitHub n instances other than ntfy.sh it's broken); this should fix that. (I believe the issue occurred cause the paths might've been copy-pasted from `/docs/subscribe/phone/`?)