### PR TITLE
Append /v2 to module so version 2 can be used as a go package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module heckel.io/ntfy
+module heckel.io/ntfy/v2
 
 go 1.18
 


### PR DESCRIPTION
When trying to import ntfy as a library in another go application, it defaults to the last v1 tag. When trying to import a v2 tag, the following error is thrown `heckel.io/ntfy@v2.7.0: invalid version: module contains a go.mod file, so module path must match major version ("heckel.io/ntfy/v2")`

This change to the go.mod allows for importing (future) v2 tags.

https://github.com/golang/go/wiki/Modules#semantic-import-versioning