### PR TITLE
Allow overriding `python3` & `pip3` binary in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ docs-venv: .PHONY
 	$(PYTHON) -m venv ./venv
 
 docs-build: docs-venv
-	(. venv/bin/activate && $(PYTHON) mkdocs build)
+	(. venv/bin/activate && $(PYTHON) -m mkdocs build)
 
 docs-deps: docs-venv
 	(. venv/bin/activate && $(PIP) install -r requirements.txt)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 MAKEFLAGS := --jobs=1
+PYTHON := python3
+PIP := pip3
 VERSION := $(shell git describe --tag)
 COMMIT := $(shell git rev-parse --short HEAD)
 
@@ -115,16 +117,16 @@ build-deps-ubuntu:
 docs: docs-deps docs-build
 
 docs-venv: .PHONY
-	python3 -m venv ./venv
+	$(PYTHON) -m venv ./venv
 
 docs-build: docs-venv
-	(. venv/bin/activate && mkdocs build)
+	(. venv/bin/activate && $(PYTHON) mkdocs build)
 
 docs-deps: docs-venv
-	(. venv/bin/activate && pip3 install -r requirements.txt)
+	(. venv/bin/activate && $(PIP) install -r requirements.txt)
 
 docs-deps-update: .PHONY
-	(. venv/bin/activate && pip3 install -r requirements.txt --upgrade)
+	(. venv/bin/activate && $(PIP) install -r requirements.txt --upgrade)
 
 
 # Web app


### PR DESCRIPTION
This is a simpler (and hopefully better) attempt to solve the problem in #665.

I believe it is still needed because on some platforms like RHEL8 (which won't be EOL until 2029), `python3` still points to `python3.6` by default, which is too old for `mkdocs`.