### PR TITLE
Update docker-dev go version

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye as builder
+FROM golang:1.21-bullseye as builder
 
 ARG VERSION=dev
 ARG COMMIT=unknown


### PR DESCRIPTION
Running `go mod tidy` in go 1.21 will add `toolchain go<version>` to `go.mod` file, which cannot be recognized by previous go versions and will cause error. ([reference](https://github.com/golang/go/issues/62409)).

This PR updates the go version in `Dockerfile-build` to 1.21 to fix build errors.