### PR TITLE
Paste images from clipboard

### DIFF
--- a/web/src/components/AttachmentIcon.jsx
+++ b/web/src/components/AttachmentIcon.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Box } from "@mui/material";
+import { Box, Link } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import fileDocument from "../img/file-document.svg";
 import fileImage from "../img/file-image.svg";
@@ -32,16 +32,18 @@ const AttachmentIcon = (props) => {
     imageLabel = t("notifications_attachment_file_document");
   }
   return (
-    <Box
-      component="img"
-      src={imageFile}
-      alt={imageLabel}
-      loading="lazy"
-      sx={{
-        width: "28px",
-        height: "28px",
-      }}
-    />
+    <Link href={props.href} target="_blank">
+      <Box
+        component="img"
+        src={imageFile}
+        alt={imageLabel}
+        loading="lazy"
+        sx={{
+          width: "28px",
+          height: "28px",
+        }}
+      />
+    </Link>
   );
 };
 

--- a/web/src/components/Messaging.jsx
+++ b/web/src/components/Messaging.jsx
@@ -74,7 +74,6 @@ const MessageBar = (props) => {
         const blob = items[i].getAsFile();
         props.onFilePasted(blob);
         props.onOpenDialogClick();
-        console.log(`[MessageBar] Pasted image`, blob);
         break;
       }
     }

--- a/web/src/components/Messaging.jsx
+++ b/web/src/components/Messaging.jsx
@@ -26,6 +26,16 @@ const Messaging = (props) => {
     setAttachFile(null);
   };
 
+  const getPastedImage = (ev) => {
+    const { items } = ev.clipboardData;
+    for (let i = 0; i < items.length; i += 1) {
+      if (items[i].type.indexOf("image") !== -1) {
+        return items[i].getAsFile();
+      }
+    }
+    return null;
+  };
+
   return (
     <>
       {subscription && (
@@ -35,6 +45,7 @@ const Messaging = (props) => {
           onMessageChange={setMessage}
           onFilePasted={setAttachFile}
           onOpenDialogClick={handleOpenDialogClick}
+          getPastedImage={getPastedImage}
         />
       )}
       <PublishDialog
@@ -44,6 +55,7 @@ const Messaging = (props) => {
         topic={subscription?.topic ?? ""}
         message={message}
         attachFile={attachFile}
+        getPastedImage={getPastedImage}
         onClose={handleDialogClose}
         onDragEnter={() => props.onDialogOpenModeChange((prev) => prev || PublishDialog.OPEN_MODE_DRAG)} // Only update if not already open
         onResetOpenMode={() => props.onDialogOpenModeChange(PublishDialog.OPEN_MODE_DEFAULT)}
@@ -67,15 +79,10 @@ const MessageBar = (props) => {
   };
 
   const handlePaste = (ev) => {
-    const clipboardData = ev.clipboardData || window.clipboardData;
-    const { items } = clipboardData;
-    for (let i = 0; i < items.length; i += 1) {
-      if (items[i].type.indexOf("image") !== -1) {
-        const blob = items[i].getAsFile();
-        props.onFilePasted(blob);
-        props.onOpenDialogClick();
-        break;
-      }
+    const blob = props.getPastedImage(ev);
+    if (blob) {
+      props.onFilePasted(blob);
+      props.onOpenDialogClick();
     }
   };
 

--- a/web/src/components/PublishDialog.jsx
+++ b/web/src/components/PublishDialog.jsx
@@ -798,7 +798,7 @@ const AttachmentBox = (props) => {
           borderRadius: "4px",
         }}
       >
-        <AttachmentIcon type={file.type} />
+        <AttachmentIcon type={file.type} href={URL.createObjectURL(file)} />
         <Box sx={{ marginLeft: 1, textAlign: "left" }}>
           <ExpandingTextField
             minWidth={140}

--- a/web/src/components/PublishDialog.jsx
+++ b/web/src/components/PublishDialog.jsx
@@ -241,6 +241,13 @@ const PublishDialog = (props) => {
     }
   }, [props.attachFile]);
 
+  const handlePaste = (ev) => {
+    const blob = props.getPastedImage(ev);
+    if (blob) {
+      updateAttachFile(blob);
+    }
+  };
+
   const handleAttachFileChanged = async (ev) => {
     await updateAttachFile(ev.target.files[0]);
   };
@@ -363,6 +370,7 @@ const PublishDialog = (props) => {
             inputProps={{
               "aria-label": t("publish_dialog_message_label"),
             }}
+            onPaste={handlePaste}
           />
           <FormControlLabel
             label={t("publish_dialog_checkbox_markdown")}

--- a/web/src/components/PublishDialog.jsx
+++ b/web/src/components/PublishDialog.jsx
@@ -238,7 +238,6 @@ const PublishDialog = (props) => {
   useEffect(() => {
     if (props.attachFile) {
       updateAttachFile(props.attachFile);
-      console.log(`[PublishDialog] Attach file changed`, props.attachFile);
     }
   }, [props.attachFile]);
 

--- a/web/src/components/PublishDialog.jsx
+++ b/web/src/components/PublishDialog.jsx
@@ -235,6 +235,13 @@ const PublishDialog = (props) => {
     await checkAttachmentLimits(file);
   };
 
+  useEffect(() => {
+    if (props.attachFile) {
+      updateAttachFile(props.attachFile);
+      console.log(`[PublishDialog] Attach file changed`, props.attachFile);
+    }
+  }, [props.attachFile]);
+
   const handleAttachFileChanged = async (ev) => {
     await updateAttachFile(ev.target.files[0]);
   };


### PR DESCRIPTION
Implement #572.

Specific behaviors:
- When the clipboard contains an image and is pasted on the MessageBar, open the PublishDialog and attach the image in the clipboard as a local file.
- Clear the attached local file when the PublishDialog is closed.
- ~~Pasting inside the PublishDialog is ineffective.~~(edit: feature added)
- When the clipboard contains an image and is pasted on the the message section of PublishDialog, the attached file will be changed to the pasted image (no matter whether it already has a file or not)

For convenience in previewing, a new feature has also been added: clicking on the icon of the attached local file will create a blob URL using `URL.createObjectURL` and open it in a new tab. This feature is effective for all attached local files.

This feature has already been tested in Chrome and Firefox (on Windows). **Testing on Safari is still needed** (I don't have Apple devices). You can test this feature at https://ntfy-clipboard.fly.dev.