### PR TITLE
Inform the client if it subscribes to a new topic

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -117,9 +117,10 @@ var (
 	errHTTPBadRequestWebPushSubscriptionInvalid      = &errHTTP{40038, http.StatusBadRequest, "invalid request: web push payload malformed", "", nil}
 	errHTTPBadRequestWebPushEndpointUnknown          = &errHTTP{40039, http.StatusBadRequest, "invalid request: web push endpoint unknown", "", nil}
 	errHTTPBadRequestWebPushTopicCountTooHigh        = &errHTTP{40040, http.StatusBadRequest, "invalid request: too many web push topic subscriptions", "", nil}
-	errHTTPNotFound                                  = &errHTTP{40401, http.StatusNotFound, "page not found", "", nil}
 	errHTTPUnauthorized                              = &errHTTP{40101, http.StatusUnauthorized, "unauthorized", "https://ntfy.sh/docs/publish/#authentication", nil}
 	errHTTPForbidden                                 = &errHTTP{40301, http.StatusForbidden, "forbidden", "https://ntfy.sh/docs/publish/#authentication", nil}
+	errHTTPNotFound                                  = &errHTTP{40401, http.StatusNotFound, "page not found", "", nil}
+	errHTTPNoSubscriberUnifiedPush                   = &errHTTP{40401, http.StatusInsufficientStorage, "cannot publish to UnifiedPush topic without previously active subscriber", "", nil}
 	errHTTPConflictUserExists                        = &errHTTP{40901, http.StatusConflict, "conflict: user already exists", "", nil}
 	errHTTPConflictTopicReserved                     = &errHTTP{40902, http.StatusConflict, "conflict: access control entry for topic or topic pattern already exists", "", nil}
 	errHTTPConflictSubscriptionExists                = &errHTTP{40903, http.StatusConflict, "conflict: topic subscription already exists", "", nil}
@@ -142,5 +143,4 @@ var (
 	errHTTPInternalErrorInvalidPath                  = &errHTTP{50002, http.StatusInternalServerError, "internal server error: invalid path", "", nil}
 	errHTTPInternalErrorMissingBaseURL               = &errHTTP{50003, http.StatusInternalServerError, "internal server error: base-url must be be configured for this feature", "https://ntfy.sh/docs/config/", nil}
 	errHTTPInternalErrorWebPushUnableToPublish       = &errHTTP{50004, http.StatusInternalServerError, "internal server error: unable to publish web push message", "", nil}
-	errHTTPInsufficientStorageUnifiedPush            = &errHTTP{50701, http.StatusInsufficientStorage, "cannot publish to UnifiedPush topic without previously active subscriber", "", nil}
 )

--- a/server/message_cache_test.go
+++ b/server/message_cache_test.go
@@ -32,8 +32,8 @@ func testCacheMessages(t *testing.T, c *messageCache) {
 	require.Nil(t, c.AddMessage(m2))
 
 	// Adding invalid
-	require.Equal(t, errUnexpectedMessageType, c.AddMessage(newKeepaliveMessage("mytopic"))) // These should not be added!
-	require.Equal(t, errUnexpectedMessageType, c.AddMessage(newOpenMessage("example")))      // These should not be added!
+	require.Equal(t, errUnexpectedMessageType, c.AddMessage(newKeepaliveMessage("mytopic")))   // These should not be added!
+	require.Equal(t, errUnexpectedMessageType, c.AddMessage(newOpenMessage("example", false))) // These should not be added!
 
 	// mytopic: count
 	counts, err := c.MessageCounts()

--- a/server/server.go
+++ b/server/server.go
@@ -848,18 +848,12 @@ func (s *Server) handlePublishMatrix(w http.ResponseWriter, r *http.Request, v *
 	if err != nil {
 		minc(metricMessagesPublishedFailure)
 		minc(metricMatrixPublishedFailure)
-		if e, ok := err.(*errHTTP); ok && e.HTTPCode == errHTTPInsufficientStorageUnifiedPush.HTTPCode {
-			topic, err := fromContext[*topic](r, contextTopic)
-			if err != nil {
-				return err
-			}
+		if e, ok := err.(*errHTTP); ok && e.HTTPCode == errHTTPNoSubscriberUnifiedPush.HTTPCode {
 			pushKey, err := fromContext[string](r, contextMatrixPushKey)
 			if err != nil {
 				return err
 			}
-			if time.Since(topic.LastAccess()) > matrixRejectPushKeyForUnifiedPushTopicWithoutRateVisitorAfter {
-				return writeMatrixResponse(w, pushKey)
-			}
+			return writeMatrixResponse(w, pushKey)
 		}
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -744,10 +744,9 @@ func (s *Server) handlePublishInternal(r *http.Request, v *visitor) (*message, e
 	}
 	if unifiedpush && s.config.VisitorSubscriberRateLimiting && t.RateVisitor() == nil {
 		// UnifiedPush clients must subscribe before publishing to allow proper subscriber-based rate limiting (see
-		// Rate-Topics header). The 5xx response is because some app servers (in particular Mastodon) will remove
-		// the subscription as invalid if any 400-499 code (except 429/408) is returned.
-		// See https://github.com/mastodon/mastodon/blob/730bb3e211a84a2f30e3e2bbeae3f77149824a68/app/workers/web/push_notification_worker.rb#L35-L46
-		return nil, errHTTPInsufficientStorageUnifiedPush.With(t)
+		// Rate-Topics header). The 404 response might remove the push subscription from application servers,
+		// but the client should resubscribe them when sent the new_topic parameter.
+		return nil, errHTTPNoSubscriberUnifiedPush.With(t)
 	} else if !util.ContainsIP(s.config.VisitorRequestExemptIPAddrs, v.ip) && !vrate.MessageAllowed() {
 		return nil, errHTTPTooManyRequestsLimitMessages.With(t)
 	} else if email != "" && !vrate.EmailAllowed() {

--- a/server/server_firebase_test.go
+++ b/server/server_firebase_test.go
@@ -92,7 +92,7 @@ func TestToFirebaseMessage_Keepalive(t *testing.T) {
 }
 
 func TestToFirebaseMessage_Open(t *testing.T) {
-	m := newOpenMessage("mytopic")
+	m := newOpenMessage("mytopic", false)
 	fbm, err := toFirebaseMessage(m, nil)
 	require.Nil(t, err)
 	require.Equal(t, "mytopic", fbm.Topic)

--- a/server/server_matrix.go
+++ b/server/server_matrix.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // Matrix Push Gateway / UnifiedPush / ntfy integration:
@@ -71,14 +70,6 @@ type matrixRequest struct {
 type matrixResponse struct {
 	Rejected []string `json:"rejected"`
 }
-
-const (
-	// matrixRejectPushKeyForUnifiedPushTopicWithoutRateVisitorAfter is the time after which a Matrix response
-	// will return an HTTP 200 with the push key (i.e. "rejected":["<pushkey>"]}), if no rate visitor has been set on
-	// the topic. Rejecting the push key will instruct the Matrix server to invalidate the pushkey and stop sending
-	// messages to it. This must be longer than topicExpungeAfter. See https://spec.matrix.org/v1.6/push-gateway-api/
-	matrixRejectPushKeyForUnifiedPushTopicWithoutRateVisitorAfter = 12 * time.Hour
-)
 
 // errMatrixPushkeyRejected represents an error when handing Matrix gateway messages
 //

--- a/server/topic.go
+++ b/server/topic.go
@@ -39,9 +39,9 @@ type subscriber func(v *visitor, msg *message) error
 // newTopic creates a new topic
 func newTopic(id string) *topic {
 	return &topic{
-		ID:          id,
-		subscribers: make(map[int]*topicSubscriber),
-		lastAccess:  time.Now(),
+		ID:              id,
+		subscribers:     make(map[int]*topicSubscriber),
+		lastAccess:      time.Now(),
 		neverSubscribed: true,
 	}
 }

--- a/server/types.go
+++ b/server/types.go
@@ -17,6 +17,7 @@ const (
 	keepaliveEvent   = "keepalive"
 	messageEvent     = "message"
 	pollRequestEvent = "poll_request"
+	createdNewTopicParameter = "new_topic"
 )
 
 const (
@@ -123,8 +124,12 @@ func newMessage(event, topic, msg string) *message {
 }
 
 // newOpenMessage is a convenience method to create an open message
-func newOpenMessage(topic string) *message {
-	return newMessage(openEvent, topic, "")
+func newOpenMessage(topic string, createdNewTopics bool) *message {
+	msg := ""
+	if createdNewTopics { // can expand this to a comma seperated string for more future parameters
+		msg = createdNewTopicParameter
+	}
+	return newMessage(openEvent, topic, msg)
 }
 
 // newKeepaliveMessage is a convenience method to create a keepalive message

--- a/server/types.go
+++ b/server/types.go
@@ -13,11 +13,11 @@ import (
 
 // List of possible events
 const (
-	openEvent        = "open"
-	keepaliveEvent   = "keepalive"
-	messageEvent     = "message"
-	pollRequestEvent = "poll_request"
-	createdNewTopicParameter = "new_topic"
+	openEvent           = "open"
+	openCreatedNewTopic = "new_topic"
+	keepaliveEvent      = "keepalive"
+	messageEvent        = "message"
+	pollRequestEvent    = "poll_request"
 )
 
 const (
@@ -127,7 +127,7 @@ func newMessage(event, topic, msg string) *message {
 func newOpenMessage(topic string, createdNewTopics bool) *message {
 	msg := ""
 	if createdNewTopics { // can expand this to a comma seperated string for more future parameters
-		msg = createdNewTopicParameter
+		msg = openCreatedNewTopic
 	}
 	return newMessage(openEvent, topic, msg)
 }


### PR DESCRIPTION
- Reject Matrix with 200 and rejected pushkey instead of returning 5xx
- Set UnifiedPush 'can't publish' error to 404
- Implement a NeverSubscribed() method in topics to keep track of new topics
- add the "new_topic" param to the open message
- Return new_topic in the open message when any of the list of topics subscribed to is new. Not the most information, but the likelihood of topics from the same client have different statuses is so tiny and rare, that clients can resubscribe all to be safe.

**Deployment**
I think the Android app needs to be released first, before the server is deployed, so the client can deal with the case of re-registration on 404.

Paired with https://github.com/binwiederhier/ntfy-android/pull/70
Closes https://github.com/binwiederhier/ntfy/issues/664