### PR TITLE
Add systemd user service for `ntfy-client.service`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,6 +90,8 @@ nfpms:
         type: "config|noreplace"
       - src: client/ntfy-client.service
         dst: /lib/systemd/system/ntfy-client.service
+      - src: client/user/ntfy-client.service
+        dst: /lib/systemd/user/ntfy-client.service
       - dst: /var/cache/ntfy
         type: dir
       - dst: /var/cache/ntfy/attachments
@@ -119,6 +121,7 @@ archives:
       - server/ntfy.service
       - client/client.yml
       - client/ntfy-client.service
+      - client/user/ntfy-client.service
   -
     id: ntfy_windows
     builds:

--- a/client/user/ntfy-client.service
+++ b/client/user/ntfy-client.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=ntfy client
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/ntfy subscribe --config "%h/.config/ntfy/client.yml" --from-config
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/docs/subscribe/cli.md
+++ b/docs/subscribe/cli.md
@@ -263,43 +263,20 @@ will be used, otherwise, the subscription settings will override the defaults.
     require authentication), be sure that the servers/topics you subscribe to use HTTPS to prevent leaking the username and password.
 
 ### Using the systemd service
-You can use the `ntfy-client` systemd service (see [ntfy-client.service](https://github.com/binwiederhier/ntfy/blob/main/client/ntfy-client.service))
-to subscribe to multiple topics just like in the example above. The service is automatically installed (but not started)
-if you install the deb/rpm package. To configure it, simply edit `/etc/ntfy/client.yml` and run `sudo systemctl restart ntfy-client`.
+You can use the `ntfy-client` systemd services to subscribe to multiple topics just like in the example above.
+You have the option of either enabling `ntfy-client` as a system service (see
+[here](https://github.com/binwiederhier/ntfy/blob/main/client/ntfy-client.service))
+or user service (see [here](https://github.com/binwiederhier/ntfy/blob/main/client/user/ntfy-client.service)).
+The services are automatically installed (but not started) if you install the deb/rpm/AUR package.
+The system service ensures that ntfy is run at startup (useful for servers),
+while the user service starts ntfy only after the user has logged in. The user service is recommended for personal machine use.
+
+To configure `ntfy-client` as a system service it, edit `/etc/ntfy/client.yml` and run `sudo systemctl restart ntfy-client`.
+
+To configure `ntfy-client` as a user service it, edit `~/.config/ntfy/client.yml` and run `systemctl --user restart ntfy-client` (without sudo).
 
 !!! info
-    The `ntfy-client.service` runs as user `ntfy`, meaning that typical Linux permission restrictions apply. See below
-    for how to fix this.
-
-If the service runs on your personal desktop machine, you may want to override the service user/group (`User=` and `Group=`), and 
-adjust the `DISPLAY` and `DBUS_SESSION_BUS_ADDRESS` environment variables. This will allow you to run commands in your X session 
-as the primary machine user.
-
-You can either manually override these systemd service entries with `sudo systemctl edit ntfy-client`, and add this
-(assuming your user is `phil`). Don't forget to run `sudo systemctl daemon-reload` and `sudo systemctl restart ntfy-client`
-after editing the service file:
-
-=== "/etc/systemd/system/ntfy-client.service.d/override.conf"
-    ```
-    [Service]
-    User=phil
-    Group=phil
-    Environment="DISPLAY=:0" "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus"
-    ```
-Or you can run the following script that creates this override config for you:
-
-```
-sudo sh -c 'cat > /etc/systemd/system/ntfy-client.service.d/override.conf' <<EOF
-[Service]
-User=$USER
-Group=$USER
-Environment="DISPLAY=:0" "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus"
-EOF
-
-sudo systemctl daemon-reload
-sudo systemctl restart ntfy-client
-```
-
+    The system service runs as user `ntfy`, meaning that typical Linux permission restrictions apply. It also means that the system service cannot run commands in your X session as the primary machine user (unlike the user service).
 
 ### Authentication
 Depending on whether the server is configured to support [access control](../config.md#access-control), some topics

--- a/scripts/postinst.sh
+++ b/scripts/postinst.sh
@@ -24,6 +24,7 @@ if [ "$1" = "configure" ] || [ "$1" -ge 1 ]; then
 
     # Restart services
     systemctl --system daemon-reload >/dev/null || true
+    systemctl --user daemon-reload >/dev/null || true
     if systemctl is-active -q ntfy.service; then
       echo "Restarting ntfy.service ..."
       if [ -x /usr/bin/deb-systemd-invoke ]; then
@@ -33,11 +34,19 @@ if [ "$1" = "configure" ] || [ "$1" -ge 1 ]; then
       fi
     fi
     if systemctl is-active -q ntfy-client.service; then
-      echo "Restarting ntfy-client.service ..."
+      echo "Restarting ntfy-client.service (system) ..."
       if [ -x /usr/bin/deb-systemd-invoke ]; then
         deb-systemd-invoke try-restart ntfy-client.service >/dev/null || true
       else
         systemctl restart ntfy-client.service >/dev/null || true
+      fi
+    fi
+    if systemctl --user is-active -q ntfy-client.service; then
+      echo "Restarting ntfy-client.service (user)..."
+      if [ -x /usr/bin/deb-systemd-invoke ]; then
+        deb-systemd-invoke --user try-restart ntfy-client.service >/dev/null || true
+      else
+        systemctl --user restart ntfy-client.service >/dev/null || true
       fi
     fi
   fi


### PR DESCRIPTION
We can offer `ntfy-client.service` as a user service along the already existing system service.

This allows the use of `~/.config/ntfy/client.yaml` for configuration (for the system service, the config is hardcoded to use
`/etc/ntfy/client.yaml`). It also means that we can update the docs to recommend enabling the user service for "personal desktop machine" use in https://docs.ntfy.sh/subscribe/cli/?h=systemd#using-the-systemd-service and remove the part about using an `override.conf` (unless this has another use case for the ntfy-client that I am missing?).

Repos would need to update their packages to copy over `client/user/ntfy-client.service` to `/usr/lib/systemd/user/ntfy-client.service`.

I've been using it successfully so far. I've also added entries to `scripts/postinst.sh` and `.goreleaser.yml`, but haven't tested those.

