### PR TITLE
Remove dependence on mkdocs-simple-hooks

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
-def copy_fonts(config, **kwargs):
-    site_dir = config['site_dir']
-    shutil.copytree('docs/static/fonts', os.path.join(site_dir, 'get'))
+
+def on_post_build(config, **kwargs):
+    site_dir = config["site_dir"]
+    shutil.copytree("docs/static/fonts", os.path.join(site_dir, "get"))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,13 +67,13 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
 
+hooks:
+  - docs/hooks.py
+
 plugins:
   - search
   - minify:
       minify_html: true
-  - mkdocs-simple-hooks:
-      hooks:
-        on_post_build: "docs.hooks:copy_fonts"
 
 nav:
   - "Getting started": index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # The documentation uses 'mkdocs', which is written in Python
 mkdocs-material
 mkdocs-minify-plugin
-mkdocs-simple-hooks


### PR DESCRIPTION
Since mkdocs v1.4, the hooks are a native feature