### PR TITLE
Clarify that Content-Length is required in the HTTP header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ simple message using a POST request:
     ``` http
     POST /mytopic HTTP/1.1
     Host: ntfy.sh
+    Content-Length: 22
     
     Backup successful 😀
     ```


### PR DESCRIPTION
Without it your message will be empty and the message will be replaced by "triggered".

I initially missed this because normally this happens when using a GET request instead of POST, so it took a bit of time to figure out I had forgotten the Content-Length header.