### PR TITLE
add templating for title and message fields

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -3557,6 +3557,29 @@ ntfy server plays the role of the Push Gateway, as well as the Push Provider. Un
 !!! info
     This is not a generic Matrix Push Gateway. It only works in combination with UnifiedPush and ntfy.
 
+### Message and Title Templates
+Some services let you specify a webhook URL but do not let you modify the webhook body (e.g., Grafana). Instead of using a separate
+bridge program to parse the webhook body into the format ntfy expects, you can include a message template and/or a title template
+which will be populated based on the fields of the webhook body (so long as the webhook body is valid JSON).
+
+Send the message template with the header `X-Template-Message`, `Template-Message`, or `tpl-m`. Send the title template with the
+header `X-Template-Title`, `Template-Title`, or `tpl-t`. (No other fields can be filled with a template at this time).
+
+In the template, include paths to the appropriate JSON fields surrounded by `${` and `}`. See an example below.
+See [GJSON docs](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for supported JSON path syntax.
+
+=== "HTTP"
+    ``` http
+    POST /mytopic HTTP/1.1
+    Host: ntfy.sh
+    X-Template-Message: Error message: ${error.desc}
+    X-Template-Title: ${hostname}: A ${error.level} error has occurred
+
+    {"hostname": "philipp-pc", "error": {"level": "severe", "desc": "Disk has run out of space"}}
+    ```
+
+The example above would send a notification with a title "philipp-pc: A severe error has occurred" and a message "Error message: Disk has run out of space".
+
 ## Public topics
 Obviously all topics on ntfy.sh are public, but there are a few designated topics that are used in examples, and topics
 that you can use to try out what [authentication and access control](#authentication) looks like.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1338,6 +1338,12 @@ and the [ntfy Android app](https://github.com/binwiederhier/ntfy-android/release
 
 ## Not released yet
 
+### ntfy server v2.9.1 (UNRELEASED)
+
+**Features:**
+
+* You can now include a message and/or title template that will be filled with values from a JSON body, great for services that let you specify a webhook URL but do not let you change the webhook body (such as Grafana). ([#724](https://github.com/binwiederhier/ntfy/issues/724), thanks to [@wunter8](https://github.com/wunter8) for implementing)
+
 ### ntfy Android app v1.16.1 (UNRELEASED)
 
 **Features:**

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,9 @@ require (
 	github.com/prometheus/procfs v0.13.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/tidwall/gjson v1.17.1 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,12 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stripe/stripe-go/v74 v74.30.0 h1:0Kf0KkeFnY7iRhOwvTerX0Ia1BRw+eV1CVJ51mGYAUY=
 github.com/stripe/stripe-go/v74 v74.30.0/go.mod h1:f9L6LvaXa35ja7eyvP6GQswoaIPaBRvGAimAO+udbBw=
+github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
+github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/urfave/cli/v2 v2.27.1 h1:8xSQ6szndafKVRmfyeUMxkNUJQMjL1F2zmsZ+qHpfho=
 github.com/urfave/cli/v2 v2.27.1/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e h1:+SOyEddqYF09QP7vr7CgJ1eti3pY9Fn3LHO1M1r/0sI=


### PR DESCRIPTION
Here's an initial working implementation, based on https://github.com/binwiederhier/ntfy/pull/171.

Right now, only the message and title fields can be templated, each using their own header (since this seemed like the quickest way to get something working).

In a future iteration, I think allowing other fields to be templated (e.g., priority, actions, attachment url, topic?, etc.) would be cool.

In that version, I was imagining an `X-Template` header that includes probably a JSON string for the different fields of a message (e.g., `{"message":"${field.value} is ${field2}", "title":"An error occurred on ${hostname}", "priority":${error.level}, "attachment":"${error.screenshot.url}"}`)