### PR TITLE
Fix username regex

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -122,7 +122,7 @@ var (
 	errHTTPBadRequestTemplateInvalid                 = &errHTTP{40043, http.StatusBadRequest, "invalid request: could not parse template", "https://ntfy.sh/docs/publish/#message-templating", nil}
 	errHTTPBadRequestTemplateDisallowedFunctionCalls = &errHTTP{40044, http.StatusBadRequest, "invalid request: template contains disallowed function calls, e.g. template, call, or define", "https://ntfy.sh/docs/publish/#message-templating", nil}
 	errHTTPBadRequestTemplateExecuteFailed           = &errHTTP{40045, http.StatusBadRequest, "invalid request: template execution failed", "https://ntfy.sh/docs/publish/#message-templating", nil}
-	errHTTPBadRequestInvalidArgument                 = &errHTTP{40046, http.StatusBadRequest, "invalid request: invalid argument", "", nil}
+	errHTTPBadRequestInvalidUsername                 = &errHTTP{40046, http.StatusBadRequest, "invalid request: invalid username", "", nil}
 	errHTTPNotFound                                  = &errHTTP{40401, http.StatusNotFound, "page not found", "", nil}
 	errHTTPUnauthorized                              = &errHTTP{40101, http.StatusUnauthorized, "unauthorized", "https://ntfy.sh/docs/publish/#authentication", nil}
 	errHTTPForbidden                                 = &errHTTP{40301, http.StatusForbidden, "forbidden", "https://ntfy.sh/docs/publish/#authentication", nil}

--- a/server/errors.go
+++ b/server/errors.go
@@ -122,6 +122,7 @@ var (
 	errHTTPBadRequestTemplateInvalid                 = &errHTTP{40043, http.StatusBadRequest, "invalid request: could not parse template", "https://ntfy.sh/docs/publish/#message-templating", nil}
 	errHTTPBadRequestTemplateDisallowedFunctionCalls = &errHTTP{40044, http.StatusBadRequest, "invalid request: template contains disallowed function calls, e.g. template, call, or define", "https://ntfy.sh/docs/publish/#message-templating", nil}
 	errHTTPBadRequestTemplateExecuteFailed           = &errHTTP{40045, http.StatusBadRequest, "invalid request: template execution failed", "https://ntfy.sh/docs/publish/#message-templating", nil}
+	errHTTPBadRequestInvalidArgument                 = &errHTTP{40046, http.StatusBadRequest, "invalid request: invalid argument", "", nil}
 	errHTTPNotFound                                  = &errHTTP{40401, http.StatusNotFound, "page not found", "", nil}
 	errHTTPUnauthorized                              = &errHTTP{40101, http.StatusUnauthorized, "unauthorized", "https://ntfy.sh/docs/publish/#authentication", nil}
 	errHTTPForbidden                                 = &errHTTP{40301, http.StatusForbidden, "forbidden", "https://ntfy.sh/docs/publish/#authentication", nil}

--- a/server/server_account.go
+++ b/server/server_account.go
@@ -37,7 +37,11 @@ func (s *Server) handleAccountCreate(w http.ResponseWriter, r *http.Request, v *
 	}
 	logvr(v, r).Tag(tagAccount).Field("user_name", newAccount.Username).Info("Creating user %s", newAccount.Username)
 	if err := s.userManager.AddUser(newAccount.Username, newAccount.Password, user.RoleUser); err != nil {
-		return err
+		if err.Error() == "invalid argument" {
+			return errHTTPBadRequestInvalidArgument
+		} else {
+			return err
+		}
 	}
 	v.AccountCreated()
 	return s.writeJSON(w, newSuccessResponse())

--- a/server/server_account.go
+++ b/server/server_account.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"heckel.io/ntfy/v2/log"
 	"heckel.io/ntfy/v2/user"
 	"heckel.io/ntfy/v2/util"
@@ -37,11 +38,10 @@ func (s *Server) handleAccountCreate(w http.ResponseWriter, r *http.Request, v *
 	}
 	logvr(v, r).Tag(tagAccount).Field("user_name", newAccount.Username).Info("Creating user %s", newAccount.Username)
 	if err := s.userManager.AddUser(newAccount.Username, newAccount.Password, user.RoleUser); err != nil {
-		if err.Error() == "invalid argument" {
-			return errHTTPBadRequestInvalidArgument
-		} else {
-			return err
+		if errors.Is(err, user.ErrInvalidArgument) {
+			return errHTTPBadRequestInvalidUsername
 		}
+		return err
 	}
 	v.AccountCreated()
 	return s.writeJSON(w, newSuccessResponse())

--- a/user/types.go
+++ b/user/types.go
@@ -241,7 +241,7 @@ const (
 )
 
 var (
-	allowedUsernameRegex     = regexp.MustCompile(`^[-_.@a-zA-Z0-9]+$`)     // Does not include Everyone (*)
+	allowedUsernameRegex     = regexp.MustCompile(`^[-_.+@a-zA-Z0-9]+$`)    // Does not include Everyone (*)
 	allowedTopicRegex        = regexp.MustCompile(`^[-_A-Za-z0-9]{1,64}$`)  // No '*'
 	allowedTopicPatternRegex = regexp.MustCompile(`^[-_*A-Za-z0-9]{1,64}$`) // Adds '*' for wildcards!
 	allowedTierRegex         = regexp.MustCompile(`^[-_A-Za-z0-9]{1,64}$`)

--- a/user/types_test.go
+++ b/user/types_test.go
@@ -64,12 +64,12 @@ func TestTierContext(t *testing.T) {
 
 func TestUsernameRegex(t *testing.T) {
 	username := "phil"
-	username_email := "phil@ntfy.sh"
-	username_email_alias := "phil+alias@ntfy.sh"
-	username_invalid := "phil\rocks"
+	usernameEmail := "phil@ntfy.sh"
+	usernameEmailAlias := "phil+alias@ntfy.sh"
+	usernameInvalid := "phil\rocks"
 
 	require.True(t, AllowedUsername(username))
-	require.True(t, AllowedUsername(username_email))
-	require.True(t, AllowedUsername(username_email_alias))
-	require.False(t, AllowedUsername(username_invalid))
+	require.True(t, AllowedUsername(usernameEmail))
+	require.True(t, AllowedUsername(usernameEmailAlias))
+	require.False(t, AllowedUsername(usernameInvalid))
 }

--- a/user/types_test.go
+++ b/user/types_test.go
@@ -61,3 +61,15 @@ func TestTierContext(t *testing.T) {
 	require.Equal(t, "price_456", context["stripe_yearly_price_id"])
 
 }
+
+func TestUsernameRegex(t *testing.T) {
+	username := "phil"
+	username_email := "phil@ntfy.sh"
+	username_email_alias := "phil+alias@ntfy.sh"
+	username_invalid := "phil\rocks"
+
+	require.True(t, AllowedUsername(username))
+	require.True(t, AllowedUsername(username_email))
+	require.True(t, AllowedUsername(username_email_alias))
+	require.False(t, AllowedUsername(username_invalid))
+}


### PR DESCRIPTION
Now you can include a "+" in your username (for example, in an email alias).

I also added some code to convert the user/types.go ErrInvalidArgument into an errHTTPBadRequestInvalidArgument so that the error message in the web UI says "invalid request: invalid argument" instead of "internal server error."

I feel like that part of the PR isn't super clean, so you might want to rewrite it (all 6 lines)