### PR TITLE
Add logrotate support: reopen log file on SIGHUP

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -5,13 +5,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/stripe/stripe-go/v74"
-	"github.com/urfave/cli/v2"
-	"github.com/urfave/cli/v2/altsrc"
-	"heckel.io/ntfy/v2/log"
-	"heckel.io/ntfy/v2/server"
-	"heckel.io/ntfy/v2/user"
-	"heckel.io/ntfy/v2/util"
 	"io/fs"
 	"math"
 	"net"
@@ -22,6 +15,14 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/stripe/stripe-go/v74"
+	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
+	"heckel.io/ntfy/v2/log"
+	"heckel.io/ntfy/v2/server"
+	"heckel.io/ntfy/v2/user"
+	"heckel.io/ntfy/v2/util"
 )
 
 func init() {
@@ -491,6 +492,9 @@ func reloadLogLevel(inputSource altsrc.InputSourceContext) error {
 		log.Info("Log level is %v, %d override(s) in place", strings.ToUpper(newLevelStr), len(overrides))
 	} else {
 		log.Info("Log level is %v", strings.ToUpper(newLevelStr))
+	}
+	if err := log.Reopen(); err != nil {
+		return fmt.Errorf("cannot reopen log file: %s", err.Error())
 	}
 	return nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -154,6 +154,23 @@ func SetOutput(w io.Writer) {
 	log.SetOutput(output)
 }
 
+func Reopen() error {
+	mu.Lock()
+	defer mu.Unlock()
+	if f, ok := output.(*os.File); ok {
+		logFile := f.Name()
+		f.Close()
+
+		w, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+		if err != nil {
+			return err
+		}
+		output = &peekLogWriter{w}
+		log.SetOutput(output)
+	}
+	return nil
+}
+
 // File returns the log file, if any, or an empty string otherwise
 func File() string {
 	mu.RLock()


### PR DESCRIPTION
Log file stays opened while server process running.
In production environment log file usually grows fast. Best practice is periodic log file rotation: ntfy.log moves to ntfy.log.1, ntfy.log.1 to ntfy.log.2 and so on. Then new empty ntfy.log file is created.
But in Linux the process continues logging to the original file despite it was renamed.
Added log file close & open on SIGHUP.