### PR TITLE
feat(server): add Cache and Firebase as keys to JSON publishing

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1862,6 +1862,12 @@ func (s *Server) transformBodyJSON(next handleFunc) handleFunc {
 		if m.Call != "" {
 			r.Header.Set("X-Call", m.Call)
 		}
+		if m.Cache != "" {
+			r.Header.Set("X-Cache", m.Cache)
+		}
+		if m.Firebase != "" {
+			r.Header.Set("X-Firebase", m.Firebase)
+		}
 		return next(w, r, v)
 	}
 }

--- a/server/types.go
+++ b/server/types.go
@@ -105,6 +105,8 @@ type publishMessage struct {
 	Filename string   `json:"filename"`
 	Email    string   `json:"email"`
 	Call     string   `json:"call"`
+	Cache    string   `json:"cache"`    // use string as it defaults to true (or use &bool instead)
+	Firebase string   `json:"firebase"` // use string as it defaults to true (or use &bool instead)
 	Delay    string   `json:"delay"`
 }
 


### PR DESCRIPTION
https://github.com/binwiederhier/ntfy/issues/1119

Add Cache and Firebase as keys to JSON publishing, as they were only possible to configure via http headers before.

---

Added the types as strings to the publishMessage struct, as they should default to true and bools would default to false if omitted from the JSON. Alternatively, `*bool` could be used and require a nil check to detect omission.