### PR TITLE
update command when runnig from docker

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -287,6 +287,7 @@ services:
     image: binwiederhier/ntfy
     container_name: ntfy
     command:
+      - ntfy
       - serve
     environment:
       - TZ=UTC    # optional: set desired timezone


### PR DESCRIPTION
I'm not sure if this is outdated across the board but I found I had to run command: ["ntfy","serve"] when using the docker image. I run ntfy from a k8s cluster with the following config:
```
    spec:
      containers:
      - image: binwiederhier/ntfy
        imagePullPolicy: IfNotPresent
        name: ntfy
        command: ["ntfy", "serve"]
        envFrom:
        - configMapRef:
            name: ntfy
        ports:
        - containerPort: 80
          name: http
          protocol: TCP
        volumeMounts:
          - mountPath: /var/lib/ntfy
            name: ntfy
      volumes:
        - name: ntfy
          persistentVolumeClaim:
            claimName: ntfy
```

happy to expand on the docs or standardize the command across all examples if need be.