### PR TITLE
Use /usr/local/bin instead of /usr/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.title="ntfy"
 LABEL org.opencontainers.image.description="Send push notifications to your phone or desktop using PUT/POST"
 
 RUN apk add --no-cache tzdata
-COPY ntfy /usr/bin
+COPY ntfy /usr/local/bin
 
 EXPOSE 80/tcp
 ENTRYPOINT ["ntfy"]

--- a/Dockerfile-arm
+++ b/Dockerfile-arm
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.description="Send push notifications to your phon
 # Alpine does not support adding "tzdata" on ARM anymore, see
 # https://github.com/binwiederhier/ntfy/issues/894
 
-COPY ntfy /usr/bin
+COPY ntfy /usr/local/bin
 
 EXPOSE 80/tcp
 ENTRYPOINT ["ntfy"]

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -53,7 +53,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0, GPL-2.0"
 LABEL org.opencontainers.image.title="ntfy"
 LABEL org.opencontainers.image.description="Send push notifications to your phone or desktop using PUT/POST"
 
-COPY --from=builder /app/dist/ntfy_linux_server/ntfy /usr/bin/ntfy
+COPY --from=builder /app/dist/ntfy_linux_server/ntfy /usr/local/bin/ntfy
 
 EXPOSE 80/tcp
 ENTRYPOINT ["ntfy"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "Typical commands (more see below):"
 	@echo "  make build                      - Build web app, documentation and server/client (sloowwww)"
 	@echo "  make cli-linux-amd64            - Build server/client binary (amd64, no web app or docs)"
-	@echo "  make install-linux-amd64        - Install ntfy binary to /usr/bin/ntfy (amd64)"
+	@echo "  make install-linux-amd64        - Install ntfy binary to /usr/local/bin/ntfy (amd64)"
 	@echo "  make web                        - Build the web app"
 	@echo "  make docs                       - Build the documentation"
 	@echo "  make check                      - Run all tests, vetting/formatting checks and linters"
@@ -68,10 +68,10 @@ help:
 	@echo "  make release-snapshot           - Create a test release"
 	@echo
 	@echo "Install locally (requires sudo):"
-	@echo "  make install-linux-amd64        - Copy amd64 binary from dist/ to /usr/bin/ntfy"
-	@echo "  make install-linux-armv6        - Copy armv6 binary from dist/ to /usr/bin/ntfy"
-	@echo "  make install-linux-armv7        - Copy armv7 binary from dist/ to /usr/bin/ntfy"
-	@echo "  make install-linux-arm64        - Copy arm64 binary from dist/ to /usr/bin/ntfy"
+	@echo "  make install-linux-amd64        - Copy amd64 binary from dist/ to /usr/local/bin/ntfy"
+	@echo "  make install-linux-armv6        - Copy armv6 binary from dist/ to /usr/local/bin/ntfy"
+	@echo "  make install-linux-armv7        - Copy armv7 binary from dist/ to /usr/local/bin/ntfy"
+	@echo "  make install-linux-arm64        - Copy arm64 binary from dist/ to /usr/local/bin/ntfy"
 	@echo "  make install-linux-deb-amd64    - Install .deb from dist/ (amd64 only)"
 	@echo "  make install-linux-deb-armv6    - Install .deb from dist/ (armv6 only)"
 	@echo "  make install-linux-deb-armv7    - Install .deb from dist/ (armv7 only)"
@@ -322,19 +322,19 @@ release-checks:
 # Installing targets
 
 install-linux-amd64: remove-binary
-	sudo cp -a dist/ntfy_linux_amd64_linux_amd64_v1/ntfy /usr/bin/ntfy
+	sudo cp -a dist/ntfy_linux_amd64_linux_amd64_v1/ntfy /usr/local/bin/ntfy
 
 install-linux-armv6: remove-binary
-	sudo cp -a dist/ntfy_linux_armv6_linux_arm_6/ntfy /usr/bin/ntfy
+	sudo cp -a dist/ntfy_linux_armv6_linux_arm_6/ntfy /usr/local/bin/ntfy
 
 install-linux-armv7: remove-binary
-	sudo cp -a dist/ntfy_linux_armv7_linux_arm_7/ntfy /usr/bin/ntfy
+	sudo cp -a dist/ntfy_linux_armv7_linux_arm_7/ntfy /usr/local/bin/ntfy
 
 install-linux-arm64: remove-binary
-	sudo cp -a dist/ntfy_linux_arm64_linux_arm64/ntfy /usr/bin/ntfy
+	sudo cp -a dist/ntfy_linux_arm64_linux_arm64/ntfy /usr/local/bin/ntfy
 
 remove-binary:
-	sudo rm -f /usr/bin/ntfy
+	sudo rm -f /usr/local/bin/ntfy
 
 install-linux-amd64-deb: purge-package
 	sudo dpkg -i dist/ntfy_*_linux_amd64.deb

--- a/client/ntfy-client.service
+++ b/client/ntfy-client.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=ntfy
 Group=ntfy
-ExecStart=/usr/bin/ntfy subscribe --config /etc/ntfy/client.yml --from-config
+ExecStart=/usr/local/bin/ntfy subscribe --config /etc/ntfy/client.yml --from-config
 Restart=on-failure
 
 [Install]

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -119,7 +119,7 @@ $ make
 Typical commands (more see below):
   make build                   - Build web app, documentation and server/client (sloowwww)
   make cli-linux-amd64         - Build server/client binary (amd64, no web app or docs)
-  make install-linux-amd64     - Install ntfy binary to /usr/bin/ntfy (amd64)
+  make install-linux-amd64     - Install ntfy binary to /usr/local/bin/ntfy (amd64)
   make web                     - Build the web app
   make docs                    - Build the documentation
   make check                   - Run all tests, vetting/formatting checks and linters

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -61,10 +61,10 @@ to notify yourself on SSH login.
 === "/etc/pam.d/sshd"
     ```
     # at the end of the file
-    session optional pam_exec.so /usr/bin/ntfy-ssh-login.sh
+    session optional pam_exec.so /usr/local/bin/ntfy-ssh-login.sh
     ```
 
-=== "/usr/bin/ntfy-ssh-login.sh"
+=== "/usr/local/bin/ntfy-ssh-login.sh"
     ```bash
     #!/bin/bash
     if [ "${PAM_TYPE}" = "open_session" ]; then

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,7 +41,7 @@ deb/rpm packages.
     ```bash
     wget https://github.com/binwiederhier/ntfy/releases/download/v2.11.0/ntfy_2.11.0_linux_armv6.tar.gz
     tar zxvf ntfy_2.11.0_linux_armv6.tar.gz
-    sudo cp -a ntfy_2.11.0_linux_armv6/ntfy /usr/bin/ntfy
+    sudo cp -a ntfy_2.11.0_linux_armv6/ntfy /usr/local/bin/ntfy
     sudo mkdir /etc/ntfy && sudo cp ntfy_2.11.0_linux_armv6/{client,server}/*.yml /etc/ntfy
     sudo ntfy serve
     ```
@@ -50,7 +50,7 @@ deb/rpm packages.
     ```bash
     wget https://github.com/binwiederhier/ntfy/releases/download/v2.11.0/ntfy_2.11.0_linux_armv7.tar.gz
     tar zxvf ntfy_2.11.0_linux_armv7.tar.gz
-    sudo cp -a ntfy_2.11.0_linux_armv7/ntfy /usr/bin/ntfy
+    sudo cp -a ntfy_2.11.0_linux_armv7/ntfy /usr/local/bin/ntfy
     sudo mkdir /etc/ntfy && sudo cp ntfy_2.11.0_linux_armv7/{client,server}/*.yml /etc/ntfy
     sudo ntfy serve
     ```
@@ -59,7 +59,7 @@ deb/rpm packages.
     ```bash
     wget https://github.com/binwiederhier/ntfy/releases/download/v2.11.0/ntfy_2.11.0_linux_arm64.tar.gz
     tar zxvf ntfy_2.11.0_linux_arm64.tar.gz
-    sudo cp -a ntfy_2.11.0_linux_arm64/ntfy /usr/bin/ntfy
+    sudo cp -a ntfy_2.11.0_linux_arm64/ntfy /usr/local/bin/ntfy
     sudo mkdir /etc/ntfy && sudo cp ntfy_2.11.0_linux_arm64/{client,server}/*.yml /etc/ntfy
     sudo ntfy serve
     ```

--- a/server/ntfy.service
+++ b/server/ntfy.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=ntfy
 Group=ntfy
-ExecStart=/usr/bin/ntfy serve --no-log-dates
+ExecStart=/usr/local/bin/ntfy serve --no-log-dates
 ExecReload=/bin/kill --signal HUP $MAINPID
 Restart=on-failure
 AmbientCapabilities=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
This commit makes the placement of binaries consistent on Linux. ntfy currently recommends /usr/local/bin for amd64 Linux but not for arm Linux.

- replaced all instances of `/usr/bin/ntfy` with `/usr/local/bin/ntfy`
- replaced two instances of `/usr/bin` with `/usr/local/bin`
    - in Dockerfile and Dockerfile-arm, the line is changed to `COPY ntfy /usr/local/bin`
    
This PR does not add anything to move binaries or remove them from the old path.