### PR TITLE
feat: allow configurable web push expiry duration

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -100,8 +100,8 @@ var flagsServe = append(
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-file", Aliases: []string{"web_push_file"}, EnvVars: []string{"NTFY_WEB_PUSH_FILE"}, Usage: "file used to store web push subscriptions"}),
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-email-address", Aliases: []string{"web_push_email_address"}, EnvVars: []string{"NTFY_WEB_PUSH_EMAIL_ADDRESS"}, Usage: "e-mail address of sender, required to use browser push services"}),
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-startup-queries", Aliases: []string{"web_push_startup_queries"}, EnvVars: []string{"NTFY_WEB_PUSH_STARTUP_QUERIES"}, Usage: "queries run when the web push database is initialized"}),
-	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-expiry-duration", Aliases: []string{"web_push_expiry_duration"}, EnvVars: []string{"NTFY_WEB_PUSH_EXPIRY_DURATION"}, Value: util.FormatDuration(server.DefaultWebPushExpiryDuration), Usage: "send web push warning notification after this time before expiring unused subscriptions"}),
-	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-expiry-warning-duration", Aliases: []string{"web_push_expiry_warning_duration"}, EnvVars: []string{"NTFY_WEB_PUSH_EXPIRY_WARNING_DURATION"}, Value: util.FormatDuration(server.DefaultWebPushExpiryWarningDuration), Usage: "automatically expire unused subscriptions after this time"}),
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-expiry-duration", Aliases: []string{"web_push_expiry_duration"}, EnvVars: []string{"NTFY_WEB_PUSH_EXPIRY_DURATION"}, Value: util.FormatDuration(server.DefaultWebPushExpiryDuration), Usage: "automatically expire unused subscriptions after this time"}),
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-expiry-warning-duration", Aliases: []string{"web_push_expiry_warning_duration"}, EnvVars: []string{"NTFY_WEB_PUSH_EXPIRY_WARNING_DURATION"}, Value: util.FormatDuration(server.DefaultWebPushExpiryWarningDuration), Usage: "send web push warning notification after this time before expiring unused subscriptions"}),
 )
 
 var cmdServe = &cli.Command{

--- a/docs/config.md
+++ b/docs/config.md
@@ -877,8 +877,8 @@ a database to keep track of the browser's subscriptions, and an admin email addr
 - `web-push-file` is a database file to keep track of browser subscription endpoints, e.g. `/var/cache/ntfy/webpush.db`
 - `web-push-email-address` is the admin email address send to the push provider, e.g. `sysadmin@example.com`
 - `web-push-startup-queries` is an optional list of queries to run on startup`
-- `web-push-expiry-warning-duration` defines the duration for which unused subscriptions are sent a warning (default is `7d`)
-- `web-push-expiry-duration` defines the duration for which unused subscriptions will expire (default is `9d`)
+- `web-push-expiry-warning-duration` defines the duration after which unused subscriptions are sent a warning (default is `7d`)
+- `web-push-expiry-duration` defines the duration after which unused subscriptions will expire (default is `9d`)
 
 Limitations:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -876,7 +876,9 @@ a database to keep track of the browser's subscriptions, and an admin email addr
 - `web-push-private-key` is the generated VAPID private key, e.g. AA2BB1234567890abcdefzxcvbnm1234567890
 - `web-push-file` is a database file to keep track of browser subscription endpoints, e.g. `/var/cache/ntfy/webpush.db`
 - `web-push-email-address` is the admin email address send to the push provider, e.g. `sysadmin@example.com`
-- `web-push-startup-queries` is an optional list of queries to run on startup` 
+- `web-push-startup-queries` is an optional list of queries to run on startup`
+- `web-push-expiry-warning-duration` defines the duration for which unused subscriptions are sent a warning (default is `7d`)
+- `web-push-expiry-duration` defines the duration for which unused subscriptions will expire (default is `9d`)
 
 Limitations:
 
@@ -904,7 +906,7 @@ web-push-email-address: sysadmin@example.com
 ```
 
 The `web-push-file` is used to store the push subscriptions. Unused subscriptions will send out a warning after 7 days,
-and will automatically expire after 9 days (not configurable). If the gateway returns an error (e.g. 410 Gone when a user has unsubscribed),
+and will automatically expire after 9 days (default). If the gateway returns an error (e.g. 410 Gone when a user has unsubscribed),
 subscriptions are also removed automatically.
 
 The web app refreshes subscriptions on start and regularly on an interval, but this file should be persisted across restarts. If the subscription


### PR DESCRIPTION
Allow the config settings `DefaultWebPushExpiryWarningDuration` and `DefaultWebPushExpiryDuration` to be configurable.

Closes #1211 