### PR TITLE
Make markdown code blocks scrollable

### DIFF
--- a/web/src/components/Notifications.jsx
+++ b/web/src/components/Notifications.jsx
@@ -189,6 +189,7 @@ const MarkdownContainer = styled("div")`
   }
 
   pre {
+    overflow-x: scroll;
     padding: 0.9rem;
   }
 


### PR DESCRIPTION
This enables a horizontal scrollbar on overflowing Markdown code blocks, which currently are visually truncated otherwise.

This is especially useful for users who want to add log-snippets to their notifications.