### PR TITLE
Add major and minor version tags to docker release flow

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -197,3 +197,15 @@ docker_manifests:
       - *arm64v8_image
       - *armv7_image
       - *armv6_image
+  - name_template: "binwiederhier/ntfy:v{{ .Major }}"
+    image_templates:
+      - *amd64_image
+      - *arm64v8_image
+      - *armv7_image
+      - *armv6_image
+  - name_template: "binwiederhier/ntfy:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - *amd64_image
+      - *arm64v8_image
+      - *armv7_image
+      - *armv6_image


### PR DESCRIPTION
Implements #1174.

This PR adds multi level [SemVer](https://medium.com/@mccode/using-semantic-versioning-for-docker-image-tags-dfde8be06699) tags to Docker in the release flow.