### PR TITLE
docs: correct mountPath for server.yml

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -540,7 +540,7 @@ kubectl apply -k /ntfy
                       cpu: 150m
                       memory: 150Mi
               volumeMounts:
-                  - mountPath: /etc/ntfy/server.yml
+                  - mountPath: /etc/ntfy
                     subPath: server.yml
                     name: config-volume # generated vie configMapGenerator from kustomization file
                   - mountPath: /var/cache/ntfy


### PR DESCRIPTION
Quick update to docs, corrects the default Kustomize deployment failing because the mountPath is a directory.

Fixes #1309