### PR TITLE
Consider aes128gcm content encoding as an indicator for UnifiedPush

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1025,7 +1025,8 @@ func (s *Server) parsePublishParams(r *http.Request, m *message) (cache bool, fi
 	}
 	template = readBoolParam(r, false, "x-template", "template", "tpl")
 	unifiedpush = readBoolParam(r, false, "x-unifiedpush", "unifiedpush", "up") // see GET too!
-	if unifiedpush {
+	contentEncoding := readParam(r, "content-encoding")
+	if unifiedpush || contentEncoding == "aes128gcm" {
 		firebase = false
 		unifiedpush = true
 	}


### PR DESCRIPTION
Without this a UnifiedPush/Web Push message with encryption would be turned into an attachment. That in itself isn't pretty but can still work, but it requires attachments to be enabled in the first place.