### PR TITLE
Websocket http error codes

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -413,7 +413,8 @@ func (s *Server) handleError(w http.ResponseWriter, r *http.Request, v *visitor,
 		} else {
 			ev.Info("WebSocket error: %s", err.Error())
 		}
-		return // Do not attempt to write to upgraded connection
+		w.WriteHeader(httpErr.HTTPCode)
+		return // Do not attempt to write any body to upgraded connection
 	}
 	if isNormalError {
 		ev.Debug("Connection closed with HTTP %d (ntfy error %d)", httpErr.HTTPCode, httpErr.Code)

--- a/server/server.go
+++ b/server/server.go
@@ -1885,14 +1885,14 @@ func (s *Server) transformMatrixJSON(next handleFunc) handleFunc {
 }
 
 func (s *Server) authorizeTopicWrite(next handleFunc) handleFunc {
-	return s.autorizeTopic(next, user.PermissionWrite)
+	return s.authorizeTopic(next, user.PermissionWrite)
 }
 
 func (s *Server) authorizeTopicRead(next handleFunc) handleFunc {
-	return s.autorizeTopic(next, user.PermissionRead)
+	return s.authorizeTopic(next, user.PermissionRead)
 }
 
-func (s *Server) autorizeTopic(next handleFunc, perm user.Permission) handleFunc {
+func (s *Server) authorizeTopic(next handleFunc, perm user.Permission) handleFunc {
 	return func(w http.ResponseWriter, r *http.Request, v *visitor) error {
 		if s.userManager == nil {
 			return next(w, r, v)


### PR DESCRIPTION
Fixes #1337 

I spent a long time working with someone on Discord to figure out why ntfy was returning a `200` code on a websocket request instead of the expected `101`.

We finally figured out the issue was that the request wasn't authorized. Turns out, ntfy was swallowing the 403 error and not writing anything to the websocket connection. An empty response was treated as a `200 OK`.

Now, ntfy will write the error codes to the websocket connection (but it still will not write any response body). So, if you try accessing a read-restricted topic using websockets now, it will correctly respond with `403 Forbidden` instead of `200 OK`.