### PR TITLE
Add piping support

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -254,6 +254,16 @@ func parseTopicMessageCommand(c *cli.Context) (topic string, message string, com
 	if c.String("message") != "" {
 		message = c.String("message")
 	}
+	
+	// If no message provided and stdin has data, read from stdin
+	if message == "" && stdinHasData() {
+		var stdinBytes []byte
+		stdinBytes, err = io.ReadAll(c.App.Reader)
+		if err != nil {
+			return
+		}
+		message = strings.TrimSpace(string(stdinBytes))
+	}
 	return
 }
 
@@ -311,4 +321,12 @@ func runAndWaitForCommand(command []string) (message string, err error) {
 	}
 	log.Debug("Command succeeded after %s: %s", runtime, prettyCmd)
 	return fmt.Sprintf("Command succeeded after %s: %s", runtime, prettyCmd), nil
+}
+
+func stdinHasData() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) == 0
 }

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -255,16 +255,14 @@ func parseTopicMessageCommand(c *cli.Context) (topic string, message string, com
 	if c.String("message") != "" {
 		message = c.String("message")
 	}
-	
-	// If no message provided and stdin has data, read from stdin
-	if message == "" && stdinHasData() {
-		var stdinBytes []byte
-		stdinBytes, err = io.ReadAll(c.App.Reader)
+	if message == "" && isStdinRedirected() {
+		var bytes []byte
+		bytes, err = io.ReadAll(c.App.Reader)
 		if err != nil {
-			log.Debug("Failed to read from stdin: %v", err)
+			log.Debug("Failed to read from stdin: %s", err.Error())
 			return
 		}
-		message = strings.TrimSpace(string(stdinBytes))
+		message = strings.TrimSpace(string(bytes))
 	}
 	return
 }
@@ -325,10 +323,10 @@ func runAndWaitForCommand(command []string) (message string, err error) {
 	return fmt.Sprintf("Command succeeded after %s: %s", runtime, prettyCmd), nil
 }
 
-func stdinHasData() bool {
+func isStdinRedirected() bool {
 	stat, err := os.Stdin.Stat()
 	if err != nil {
-		log.Debug("Failed to stat stdin: %v", err)
+		log.Debug("Failed to stat stdin: %s", err.Error())
 		return false
 	}
 	return (stat.Mode() & os.ModeCharDevice) == 0

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -256,13 +256,13 @@ func parseTopicMessageCommand(c *cli.Context) (topic string, message string, com
 		message = c.String("message")
 	}
 	if message == "" && isStdinRedirected() {
-		var bytes []byte
-		bytes, err = io.ReadAll(c.App.Reader)
+		var data []byte
+		data, err = io.ReadAll(io.LimitReader(c.App.Reader, 1024*1024))
 		if err != nil {
 			log.Debug("Failed to read from stdin: %s", err.Error())
 			return
 		}
-		message = strings.TrimSpace(string(bytes))
+		message = strings.TrimSpace(string(data))
 	}
 	return
 }

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -69,6 +69,7 @@ Examples:
   ntfy pub --icon="http://some.tld/icon.png" 'Icon!'      # Send notification with custom icon
   ntfy pub --attach="http://some.tld/file.zip" files      # Send ZIP archive from URL as attachment
   ntfy pub --file=flower.jpg flowers 'Nice!'              # Send image.jpg as attachment
+  echo 'message' | ntfy publish mytopic                   # Send message from stdin
   ntfy pub -u phil:mypass secret Psst                     # Publish with username/password
   ntfy pub --wait-pid 1234 mytopic                        # Wait for process 1234 to exit before publishing
   ntfy pub --wait-cmd mytopic rsync -av ./ /tmp/a         # Run command and publish after it completes
@@ -260,6 +261,7 @@ func parseTopicMessageCommand(c *cli.Context) (topic string, message string, com
 		var stdinBytes []byte
 		stdinBytes, err = io.ReadAll(c.App.Reader)
 		if err != nil {
+			log.Debug("Failed to read from stdin: %v", err)
 			return
 		}
 		message = strings.TrimSpace(string(stdinBytes))
@@ -326,6 +328,7 @@ func runAndWaitForCommand(command []string) (message string, err error) {
 func stdinHasData() bool {
 	stat, err := os.Stdin.Stat()
 	if err != nil {
+		log.Debug("Failed to stat stdin: %v", err)
 		return false
 	}
 	return (stat.Mode() & os.ModeCharDevice) == 0


### PR DESCRIPTION
The client will automatically detect piped input and use it as the message content when no explicit message is provided.

- Added stdin detection: The isStdinRedirected() function detects when data is being piped by checking if stdin is not a character device
- Automatic reading: When no message is provided via arguments and stdin has data, it automatically reads the piped content
- Preserves existing behavior: Still works with explicit `--file=-` and doesn't break any existing functionality

Example : `echo "test message from stdin" | ntfy publish mytopic`