### PR TITLE
Add missing double-quote to docs so commands work when copy-pasted

### DIFF
--- a/docs/subscribe/cli.md
+++ b/docs/subscribe/cli.md
@@ -156,7 +156,7 @@ environment variables. Here are a few examples:
 ```
 ntfy sub mytopic 'notify-send "$m"'
 ntfy sub topic1 /my/script.sh
-ntfy sub topic1 'echo "Message $m was received. Its title was $t and it had priority $p'
+ntfy sub topic1 'echo "Message $m was received. Its title was $t and it had priority $p"'
 ```
 
 <figure>


### PR DESCRIPTION
## The issue

- One of the code snippet examples was missing a closing `"`, making it easy for the inattentive (like me 😓 ) to get confused when copy-pasting it.

## The fix:

- Slap a `"` on that code snippet

## Notes:

Saw this when onboarding (I _love_ the project), and thought I'd boy-scout it by adding a small fix.