### PR TITLE
Add Ntfy for Sandstorm to integrations.md

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -176,6 +176,7 @@ I've added a ⭐ to projects or posts that have a significant following, or had 
 - [InvaderInformant](https://github.com/patricksthannon/InvaderInformant) - Script for Mac OS systems that monitors new or dropped connections to your network using ntfy (Shell)
 - [NtfyPwsh](https://github.com/ptmorris1/NtfyPwsh) - PowerShell module to help send messages to ntfy (PowerShell)
 - [ntfyrr](https://github.com/leukosaima/ntfyrr) - Currently an Overseerr webhook notification to ntfy helper service.
+- [ntfy for Sandstorm](https://apps.sandstorm.io/app/c6rk81r4qk6dm3k04x1kxmyccqewhh4npuxeyg1xrpfypn2ddy0h) - ntfy app for the Sandstorm platform
 
 ## Blog + forum posts
 


### PR DESCRIPTION
I packaged ntfy for [Sandstorm](https://sandstorm.org), a self-hosting platform (similar to Yunohost, but more container based). Check out the link that I'm adding to see some details about my package. You can also run a demo of the app from there. It spins it up on the "alpha" server and deletes your account after some time.

Sandstorm is fairly opinionated, blocking unknown headers and also auth headers. So that precludes some of ntfy's features. I took out anything from the UI that rely on any of these, and also add a warning about it there to the user. Importantly, UnifiedPush works for me, as do my own json-based integrations in my personal scripts. I expect any integrations that don't rely on those headers to work. TBH probably most of my time was spent looking carefully into all of this.

I also added some onboarding text, since users may be coming from the Sandstorm app store, hearing about ntfy for the first time. I'd like to make it less "wall of text" and more streamlined and interactive in future versions. But I'm curious if something like this could be good for upstream as well?

The main benefit of choosing ntfy on Sandstorm is that it's really easy to spin up, and also to delete. And, it's conveniently alongside a growing list of other easy to install apps. Because Sandstorm is meant for "bite sized" apps owned by single users, I tell users to not share their ntfy instance with others. (other users can create their own). Users can create a new API URL for each integration, which makes it easy to revoke it later (not counting UnifiedPush, since that's tied to your phone). In the long run, I'd like to add some more features that you wouldn't want on a public server, like some sort of dashboard (if that runs too far away from your vision, I could change the branding. But I'd like it to work with the ntfy Android app.).

Over time I'd like to integrate it into Sandstorm more deeply. Sandstorm has something called the "powerbox" that lets you create interfaces between apps with CapnProto. It'll take some time to learn, but I'd love to make it so that we could create a package for (let's say) Changedetector.io, and allow the user to connect it to their ntfy instance with a few clicks instead of having to copy around API URLs.