### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/util/sprig/defaults.go
+++ b/util/sprig/defaults.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -95,12 +96,7 @@ func coalesce(v ...any) any {
 // Returns:
 //   - bool: True if all values are non-empty, false otherwise
 func all(v ...any) bool {
-	for _, val := range v {
-		if empty(val) {
-			return false
-		}
-	}
-	return true
+	return !slices.ContainsFunc(v, empty)
 }
 
 // anyNonEmpty checks if at least one value in a list is non-empty.

--- a/util/util.go
+++ b/util/util.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -49,12 +50,7 @@ func FileExists(filename string) bool {
 
 // Contains returns true if needle is contained in haystack
 func Contains[T comparable](haystack []T, needle T) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }
 
 // ContainsIP returns true if any one of the of prefixes contains the ip.


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.