### PR TITLE
feat(docs): add ntfy-heartbeat-monitor to integrations page

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -177,6 +177,7 @@ I've added a ⭐ to projects or posts that have a significant following, or had 
 - [NtfyPwsh](https://github.com/ptmorris1/NtfyPwsh) - PowerShell module to help send messages to ntfy (PowerShell)
 - [ntfyrr](https://github.com/leukosaima/ntfyrr) - Currently an Overseerr webhook notification to ntfy helper service.
 - [ntfy for Sandstorm](https://apps.sandstorm.io/app/c6rk81r4qk6dm3k04x1kxmyccqewhh4npuxeyg1xrpfypn2ddy0h) - ntfy app for the Sandstorm platform
+- [ntfy-heartbeat-monitor](https://codeberg.org/RockWolf/ntfy-heartbeat-monitor) - Application for implementing heartbeat monitoring/alerting by utilizing ntfy
 
 ## Blog + forum posts
 


### PR DESCRIPTION
I've written a small tool to implement heartbeat monitoring/alerting.
My main use-case is to be alerted if something in my alerting pipeline is broken.

It works by monitoring messages in a ntfy topic. If the last message is older than a given threshold, or if we can't retrieve the last message because the ntfy server is down/unavailable, a message is sent to a different ntfy topic (usually also on a different ntfy server).
If you have two or more "sites" you could monitor everything in a mesh like way :smile: 