### PR TITLE
Fix base64 snippets in Publishing

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -3679,13 +3679,13 @@ authParam  = base64_raw(authHeader) // -> QmFzaWMgZEdWemRIVnpaWEk2Wm1GclpYQmhjM0
 The following command will generate the appropriate value for you on *nix systems:
 
 ```
-echo -n "Basic `echo -n 'testuser:fakepassword' | base64`" | base64 | tr -d '='
+echo -n "Basic `echo -n 'testuser:fakepassword' | base64 -w0`" | base64 -w0 | tr -d '='
 ```
 
 For access tokens, you can use this instead:
 
 ```
-echo -n "Bearer faketoken" | base64 | tr -d '='
+echo -n "Bearer faketoken" | base64 -w0 | tr -d '='
 ```
 
 ## Advanced features


### PR DESCRIPTION
`-w0` is usually needed for longer outputs

Might be GNU-specific, though.

To quote the man page

>        -w, --wrap=COLS
>               wrap encoded lines after COLS character (default 76).  Use 0 to disable line wrapping