### PR TITLE
convert old for loops to range functions

### DIFF
--- a/server/file_cache_test.go
+++ b/server/file_cache_test.go
@@ -26,7 +26,7 @@ func TestFileCache_Write_Success(t *testing.T) {
 
 func TestFileCache_Write_Remove_Success(t *testing.T) {
 	dir, c := newTestFileCache(t) // max = 10k (10240), each = 1k (1024)
-	for i := 0; i < 10; i++ {     // 10x999 = 9990
+	for i := range 10 {           // 10x999 = 9990
 		size, err := c.Write(fmt.Sprintf("abcdefghijk%d", i), bytes.NewReader(make([]byte, 999)))
 		require.Nil(t, err)
 		require.Equal(t, int64(999), size)
@@ -45,7 +45,7 @@ func TestFileCache_Write_Remove_Success(t *testing.T) {
 
 func TestFileCache_Write_FailedTotalSizeLimit(t *testing.T) {
 	dir, c := newTestFileCache(t)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		size, err := c.Write(fmt.Sprintf("abcdefghijk%d", i), bytes.NewReader(oneKilobyteArray))
 		require.Nil(t, err)
 		require.Equal(t, int64(1024), size)

--- a/server/message_cache_test.go
+++ b/server/message_cache_test.go
@@ -102,7 +102,7 @@ func TestMemCache_MessagesLock(t *testing.T) {
 
 func testCacheMessagesLock(t *testing.T, c *messageCache) {
 	var wg sync.WaitGroup
-	for i := 0; i < 5000; i++ {
+	for range 5000 {
 		wg.Add(1)
 		go func() {
 			assert.Nil(t, c.AddMessage(newDefaultMessage("mytopic", "test message")))
@@ -464,7 +464,7 @@ func TestSqliteCache_Migration_From0(t *testing.T) {
 	require.Nil(t, err)
 
 	// Insert a bunch of messages
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		_, err = db.Exec(`INSERT INTO messages (id, time, topic, message) VALUES (?, ?, ?, ?)`,
 			fmt.Sprintf("abcd%d", i), time.Now().Unix(), "mytopic", fmt.Sprintf("some message %d", i))
 		require.Nil(t, err)
@@ -510,7 +510,7 @@ func TestSqliteCache_Migration_From1(t *testing.T) {
 	require.Nil(t, err)
 
 	// Insert a bunch of messages
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		_, err = db.Exec(`INSERT INTO messages (id, time, topic, message, title, priority, tags) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 			fmt.Sprintf("abcd%d", i), time.Now().Unix(), "mytopic", fmt.Sprintf("some message %d", i), "", 0, "")
 		require.Nil(t, err)
@@ -594,7 +594,7 @@ func TestSqliteCache_Migration_From9(t *testing.T) {
 		INSERT INTO messages (mid, time, topic, message, title, priority, tags, click, icon, actions, attachment_name, attachment_type, attachment_size, attachment_expires, attachment_url, sender, encoding, published) 
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		_, err = db.Exec(
 			insertQuery,
 			fmt.Sprintf("abcd%d", i),

--- a/server/server_account_test.go
+++ b/server/server_account_test.go
@@ -71,7 +71,7 @@ func TestAccount_Signup_LimitReached(t *testing.T) {
 	s := newTestServer(t, conf)
 	defer s.closeDatabases()
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		rr := request(t, s, "POST", "/v1/account", fmt.Sprintf(`{"username":"phil%d", "password":"mypass"}`, i), nil)
 		require.Equal(t, 200, rr.Code)
 	}
@@ -118,7 +118,7 @@ func TestAccount_Signup_Rate_Limit(t *testing.T) {
 	conf.EnableSignup = true
 	s := newTestServer(t, conf)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		rr := request(t, s, "POST", "/v1/account", fmt.Sprintf(`{"username":"phil%d", "password":"mypass"}`, i), nil)
 		require.Equal(t, 200, rr.Code, "failed on iteration %d", i)
 	}

--- a/server/server_payments_test.go
+++ b/server/server_payments_test.go
@@ -331,7 +331,7 @@ func TestPayments_Checkout_Success_And_Increase_Rate_Limits_Reset_Visitor(t *tes
 		Return(&stripe.Customer{}, nil)
 
 	// Send messages until rate limit of free tier is hit
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		rr := request(t, s, "PUT", "/mytopic", "some message", map[string]string{
 			"Authorization": util.BasicAuth("phil", "phil"),
 		})
@@ -374,7 +374,7 @@ func TestPayments_Checkout_Success_And_Increase_Rate_Limits_Reset_Visitor(t *tes
 
 	// Now for the fun part: Verify that new rate limits are immediately applied
 	// This only tests the request limiter, which kicks in before the message limiter.
-	for i := 0; i < 11; i++ {
+	for i := range 11 {
 		rr := request(t, s, "PUT", "/mytopic", "some message", map[string]string{
 			"Authorization": util.BasicAuth("phil", "phil"),
 		})
@@ -390,7 +390,7 @@ func TestPayments_Checkout_Success_And_Increase_Rate_Limits_Reset_Visitor(t *tes
 	v.requestLimiter = rate.NewLimiter(rate.Every(time.Millisecond), 1000000)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 209; i++ {
+	for i := range 209 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -884,7 +884,7 @@ func TestServer_Auth_Fail_Rate_Limiting(t *testing.T) {
 	c.VisitorAuthFailureLimitBurst = 10
 	s := newTestServer(t, c)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		response := request(t, s, "PUT", "/announcements", "test", map[string]string{
 			"Authorization": util.BasicAuth("phil", "phil"),
 		})
@@ -960,7 +960,7 @@ func TestServer_StatsResetter(t *testing.T) {
 	require.Equal(t, 200, response.Code)
 
 	// Send messages from user without tier (phil)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		response := request(t, s, "PUT", "/mytopic", "test", map[string]string{
 			"Authorization": util.BasicAuth("phil", "phil"),
 		})
@@ -968,7 +968,7 @@ func TestServer_StatsResetter(t *testing.T) {
 	}
 
 	// Send messages from user with tier
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		response := request(t, s, "PUT", "/mytopic", "test", map[string]string{
 			"Authorization": util.BasicAuth("tieruser", "tieruser"),
 		})
@@ -1046,7 +1046,7 @@ func TestServer_StatsResetter_MessageLimiter_EmailsLimiter(t *testing.T) {
 	s.smtpSender = &testMailer{}
 
 	// Publish some messages, and check stats
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		response := request(t, s, "PUT", "/mytopic", "test", nil)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1147,7 +1147,7 @@ func (t *testMailer) Count() int {
 
 func TestServer_PublishTooManyRequests_Defaults(t *testing.T) {
 	s := newTestServer(t, newTestConfig(t))
-	for i := 0; i < 60; i++ {
+	for i := range 60 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1163,11 +1163,11 @@ func TestServer_PublishTooManyRequests_Defaults_IPv6(t *testing.T) {
 	overrideRemoteAddr2 := func(r *http.Request) {
 		r.RemoteAddr = "[2001:db8:9999:8888:2::1]:1234" // Same /64
 	}
-	for i := 0; i < 30; i++ {
+	for i := range 30 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil, overrideRemoteAddr1)
 		require.Equal(t, 200, response.Code)
 	}
-	for i := 0; i < 30; i++ {
+	for i := range 30 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil, overrideRemoteAddr2)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1186,11 +1186,11 @@ func TestServer_PublishTooManyRequests_IPv6_Slash48(t *testing.T) {
 	overrideRemoteAddr2 := func(r *http.Request) {
 		r.RemoteAddr = "[2001:db8:9999::2]:1234" // Same /48
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil, overrideRemoteAddr1)
 		require.Equal(t, 200, response.Code)
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil, overrideRemoteAddr2)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1203,7 +1203,7 @@ func TestServer_PublishTooManyRequests_Defaults_ExemptHosts(t *testing.T) {
 	c.VisitorRequestLimitBurst = 3
 	c.VisitorRequestExemptPrefixes = []netip.Prefix{netip.MustParsePrefix("9.9.9.9/32")} // see request()
 	s := newTestServer(t, c)
-	for i := 0; i < 5; i++ { // > 3
+	for i := range 5 { // > 3
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1217,7 +1217,7 @@ func TestServer_PublishTooManyRequests_Defaults_ExemptHosts_IPv6(t *testing.T) {
 	overrideRemoteAddr := func(r *http.Request) {
 		r.RemoteAddr = "[2001:db8:9999::1]:1234"
 	}
-	for i := 0; i < 5; i++ { // > 3
+	for i := range 5 { // > 3
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil, overrideRemoteAddr)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1229,7 +1229,7 @@ func TestServer_PublishTooManyRequests_Defaults_ExemptHosts_MessageDailyLimit(t 
 	c.VisitorMessageDailyLimit = 4
 	c.VisitorRequestExemptPrefixes = []netip.Prefix{netip.MustParsePrefix("9.9.9.9/32")} // see request()
 	s := newTestServer(t, c)
-	for i := 0; i < 8; i++ { // 4
+	for range 8 { // 4
 		response := request(t, s, "PUT", "/mytopic", "message", nil)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1241,7 +1241,7 @@ func TestServer_PublishTooManyRequests_ShortReplenish(t *testing.T) {
 	c.VisitorRequestLimitBurst = 60
 	c.VisitorRequestLimitReplenish = time.Second
 	s := newTestServer(t, c)
-	for i := 0; i < 60; i++ {
+	for i := range 60 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), nil)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1256,7 +1256,7 @@ func TestServer_PublishTooManyRequests_ShortReplenish(t *testing.T) {
 func TestServer_PublishTooManyEmails_Defaults(t *testing.T) {
 	s := newTestServer(t, newTestConfig(t))
 	s.smtpSender = &testMailer{}
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), map[string]string{
 			"E-Mail": "test@example.com",
 		})
@@ -1274,7 +1274,7 @@ func TestServer_PublishTooManyEmails_Replenish(t *testing.T) {
 	c.VisitorEmailLimitReplenish = 500 * time.Millisecond
 	s := newTestServer(t, c)
 	s.smtpSender = &testMailer{}
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("message %d", i), map[string]string{
 			"E-Mail": "test@example.com",
 		})
@@ -1673,7 +1673,7 @@ func TestServer_PublishAsJSON_RateLimit_MessageDailyLimit(t *testing.T) {
 	c.VisitorMessageDailyLimit = 3
 	s := newTestServer(t, c)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		response := request(t, s, "PUT", "/", `{"topic":"mytopic","message":"A message"}`, nil)
 		require.Equal(t, 200, response.Code)
 	}
@@ -1783,7 +1783,7 @@ func TestServer_PublishWithTierBasedMessageLimitAndExpiry(t *testing.T) {
 	require.Nil(t, s.userManager.ChangeTier("phil", "test"))
 
 	// Publish to reach message limit
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		response := request(t, s, "PUT", "/mytopic", fmt.Sprintf("this is message %d", i+1), map[string]string{
 			"Authorization": util.BasicAuth("phil", "phil"),
 		})
@@ -2120,7 +2120,7 @@ func TestServer_PublishAttachmentWithTierBasedLimits(t *testing.T) {
 	require.Equal(t, 41301, toHTTPError(t, response.Body.String()).Code)
 
 	// Publish large file as phil (4x)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		response = request(t, s, "PUT", "/mytopic", largeFile, map[string]string{
 			"Authorization": util.BasicAuth("phil", "phil"),
 		})
@@ -2330,7 +2330,7 @@ func TestServer_PublishWhileUpdatingStatsWithLotsOfMessages(t *testing.T) {
 	log.Info("Adding %d messages", count)
 	start := time.Now()
 	messages := make([]*message, 0)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		topicID := fmt.Sprintf("topic%d", i)
 		_, err := s.topicsFromIDs(topicID) // Add topic to internal s.topics array
 		require.Nil(t, err)
@@ -2425,7 +2425,7 @@ func TestServer_SubscriberRateLimiting_Success(t *testing.T) {
 
 	// Publish 2 messages to "subscriber1topic" as visitor 9.9.9.9. It'd be 3 normally, but the
 	// GET request before is also counted towards the request limiter.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		rr := request(t, s, "PUT", "/upAAAAAAAAAAAA", "some message", nil)
 		require.Equal(t, 200, rr.Code)
 	}
@@ -2433,7 +2433,7 @@ func TestServer_SubscriberRateLimiting_Success(t *testing.T) {
 	require.Equal(t, 429, rr.Code)
 
 	// Publish another 2 messages to "up012345678912" as visitor 9.9.9.9
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		rr := request(t, s, "PUT", "/up012345678912", "some message", nil)
 		require.Equal(t, 200, rr.Code) // If we fail here, handlePublish is using the wrong visitor!
 	}
@@ -2445,7 +2445,7 @@ func TestServer_SubscriberRateLimiting_Success(t *testing.T) {
 
 	// Now let's confirm that so far we haven't used up any of visitor 9.9.9.9's request limiter
 	// by publishing another 3 requests from it.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		rr := request(t, s, "PUT", "/some-other-topic", "some message", nil)
 		require.Equal(t, 200, rr.Code)
 	}
@@ -2494,7 +2494,7 @@ func TestServer_SubscriberRateLimiting_NotEnabled_Failed(t *testing.T) {
 	require.Nil(t, s.topics["up012345678912"].rateVisitor)
 
 	// Publish 3 messages to "upAAAAAAAAAAAA" as visitor 9.9.9.9
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		rr := request(t, s, "PUT", "/subscriber1topic", "some message", nil)
 		require.Equal(t, 200, rr.Code)
 	}
@@ -2511,7 +2511,7 @@ func TestServer_SubscriberRateLimiting_UP_Only(t *testing.T) {
 	s := newTestServer(t, c)
 
 	// "Register" 5 different UnifiedPush visitors
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		subscriberFn := func(r *http.Request) {
 			r.RemoteAddr = fmt.Sprintf("1.2.3.%d:1234", i+1)
 		}
@@ -2520,8 +2520,8 @@ func TestServer_SubscriberRateLimiting_UP_Only(t *testing.T) {
 	}
 
 	// Publish 2 messages per topic
-	for i := 0; i < 5; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 5 {
+		for range 2 {
 			rr := request(t, s, "PUT", fmt.Sprintf("/up12345678901%d?up=1", i), "some message", nil)
 			require.Equal(t, 200, rr.Code)
 		}
@@ -2535,7 +2535,7 @@ func TestServer_Matrix_SubscriberRateLimiting_UP_Only(t *testing.T) {
 	s := newTestServer(t, c)
 
 	// "Register" 5 different UnifiedPush visitors
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		rr := request(t, s, "GET", fmt.Sprintf("/up12345678901%d/json?poll=1", i), "", nil, func(r *http.Request) {
 			r.RemoteAddr = fmt.Sprintf("1.2.3.%d:1234", i+1)
 		})
@@ -2543,9 +2543,9 @@ func TestServer_Matrix_SubscriberRateLimiting_UP_Only(t *testing.T) {
 	}
 
 	// Publish 2 messages per topic
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		notification := fmt.Sprintf(`{"notification":{"devices":[{"pushkey":"http://127.0.0.1:12345/up12345678901%d?up=1"}]}}`, i)
-		for j := 0; j < 2; j++ {
+		for range 2 {
 			response := request(t, s, "POST", "/_matrix/push/v1/notify", notification, nil)
 			require.Equal(t, 200, response.Code)
 			require.Equal(t, `{"rejected":[]}`+"\n", response.Body.String())
@@ -2616,7 +2616,7 @@ func TestServer_MessageHistoryAndStatsEndpoint(t *testing.T) {
 	s := newTestServer(t, c)
 
 	// Publish some messages, and get stats
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		response := request(t, s, "POST", "/mytopic", "some message", nil)
 		require.Equal(t, 200, response.Code)
 	}
@@ -2636,7 +2636,7 @@ func TestServer_MessageHistoryAndStatsEndpoint(t *testing.T) {
 	require.Equal(t, `{"messages":5,"messages_rate":2.5}`+"\n", response.Body.String()) // 5 messages in 2 seconds = 2.5 messages per second
 
 	// Publish some more messages
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		response := request(t, s, "POST", "/mytopic", "some message", nil)
 		require.Equal(t, 200, response.Code)
 	}
@@ -2659,7 +2659,7 @@ func TestServer_MessageHistoryAndStatsEndpoint(t *testing.T) {
 func TestServer_MessageHistoryMaxSize(t *testing.T) {
 	t.Parallel()
 	s := newTestServer(t, newTestConfig(t))
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		s.messages = int64(i)
 		s.execManager()
 	}

--- a/server/topic.go
+++ b/server/topic.go
@@ -48,7 +48,7 @@ func newTopic(id string) *topic {
 func (t *topic) Subscribe(s subscriber, userID string, cancel func()) (subscriberID int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for i := 0; i < 5; i++ { // Best effort retry
+	for i := range 5 { // Best effort retry
 		subscriberID = rand.Int()
 		_, exists := t.subscribers[subscriberID]
 		if !exists {

--- a/server/webpush_store_test.go
+++ b/server/webpush_store_test.go
@@ -34,7 +34,7 @@ func TestWebPushStore_UpsertSubscription_SubscriberIPLimitReached(t *testing.T) 
 	defer webPush.Close()
 
 	// Insert 10 subscriptions with the same IP address
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		endpoint := fmt.Sprintf(testWebPushEndpoint+"%d", i)
 		require.Nil(t, webPush.UpsertSubscription(endpoint, "auth-key", "p256dh-key", "u_1234", netip.MustParseAddr("1.2.3.4"), []string{"test-topic", "mytopic"}))
 	}

--- a/test/util.go
+++ b/test/util.go
@@ -10,7 +10,7 @@ import (
 // WaitForPortUp waits up to 7s for a port to come up and fails t if that fails
 func WaitForPortUp(t *testing.T, port int) {
 	success := false
-	for i := 0; i < 500; i++ {
+	for range 500 {
 		startTime := time.Now()
 		conn, _ := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 10*time.Millisecond)
 		if conn != nil {
@@ -30,7 +30,7 @@ func WaitForPortUp(t *testing.T, port int) {
 // WaitForPortDown waits up to 5s for a port to come down and fails t if that fails
 func WaitForPortDown(t *testing.T, port int) {
 	success := false
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		conn, _ := net.DialTimeout("tcp", net.JoinHostPort("", strconv.Itoa(port)), 50*time.Millisecond)
 		if conn == nil {
 			success = true

--- a/tools/loadgen/main.go
+++ b/tools/loadgen/main.go
@@ -14,11 +14,11 @@ func main() {
 	if len(os.Args) > 1 {
 		baseURL = os.Args[1]
 	}
-	for i := 0; i < 2000; i++ {
+	for i := range 2000 {
 		go subscribe(i, baseURL)
 	}
 	time.Sleep(5 * time.Second)
-	for i := 0; i < 2000; i++ {
+	for i := range 2000 {
 		go func(worker int) {
 			for {
 				poll(worker, baseURL)

--- a/user/manager_test.go
+++ b/user/manager_test.go
@@ -680,7 +680,7 @@ func TestManager_Token_MaxCount_AutoDelete(t *testing.T) {
 	// Create 62 tokens for ben (only 60 allowed!)
 	baseTime := time.Now().Add(24 * time.Hour)
 	benTokens := make([]string, 0)
-	for i := 0; i < 62; i++ { //
+	for i := range 62 {
 		token, err := a.CreateToken(ben.ID, "", time.Now().Add(72*time.Hour), netip.IPv4Unspecified(), false)
 		require.Nil(t, err)
 		require.NotEmpty(t, token.Value)
@@ -707,7 +707,7 @@ func TestManager_Token_MaxCount_AutoDelete(t *testing.T) {
 	}
 
 	// Phil: All tokens should still work
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		userWithToken, err := a.AuthenticateToken(philTokens[i])
 		require.Nil(t, err, "token[%d]=%s failed", i, philTokens[i])
 		require.Equal(t, "phil", userWithToken.Name)
@@ -1015,7 +1015,7 @@ func TestManager_Tier_Change_And_Reset(t *testing.T) {
 	require.Nil(t, a.ChangeTier("phil", "pro"))
 
 	// Add 10 reservations (pro tier allows that)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		require.Nil(t, a.AddReservation("phil", fmt.Sprintf("topic%d", i), PermissionWrite))
 	}
 

--- a/util/batching_queue_test.go
+++ b/util/batching_queue_test.go
@@ -21,7 +21,7 @@ func TestBatchingQueue_InfTimeout(t *testing.T) {
 			mu.Unlock()
 		}
 	}()
-	for i := 0; i < 101; i++ {
+	for i := range 101 {
 		go q.Enqueue(i)
 	}
 	time.Sleep(time.Second)
@@ -43,7 +43,7 @@ func TestBatchingQueue_WithTimeout(t *testing.T) {
 			mu.Unlock()
 		}
 	}()
-	for i := 0; i < 101; i++ {
+	for i := range 101 {
 		go func(i int) {
 			time.Sleep(time.Duration(rand.Intn(700)) * time.Millisecond)
 			q.Enqueue(i)

--- a/util/limit.go
+++ b/util/limit.go
@@ -174,7 +174,7 @@ func NewLimitWriter(w io.Writer, limiters ...Limiter) *LimitWriter {
 func (w *LimitWriter) Write(p []byte) (n int, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	for i := 0; i < len(w.limiters); i++ {
+	for i := range len(w.limiters) {
 		if !w.limiters[i].AllowN(int64(len(p))) {
 			for j := i - 1; j >= 0; j-- {
 				w.limiters[j].AllowN(-int64(len(p))) // Revert limiters limits if not allowed

--- a/util/sprig/dict.go
+++ b/util/sprig/dict.go
@@ -202,7 +202,7 @@ func dig(ps ...any) (any, error) {
 	dict := ps[len(ps)-1].(map[string]any)
 	def := ps[len(ps)-2]
 	ks := make([]string, len(ps)-2)
-	for i := 0; i < len(ks); i++ {
+	for i := range len(ks) {
 		ks[i] = ps[i].(string)
 	}
 

--- a/util/sprig/list.go
+++ b/util/sprig/list.go
@@ -37,7 +37,7 @@ func mustPush(list any, v any) ([]any, error) {
 		l2 := reflect.ValueOf(list)
 		l := l2.Len()
 		nl := make([]any, l)
-		for i := 0; i < l; i++ {
+		for i := range l {
 			nl[i] = l2.Index(i).Interface()
 		}
 		return append(nl, v), nil
@@ -66,7 +66,7 @@ func mustPrepend(list any, v any) ([]any, error) {
 		l2 := reflect.ValueOf(list)
 		l := l2.Len()
 		nl := make([]any, l)
-		for i := 0; i < l; i++ {
+		for i := range l {
 			nl[i] = l2.Index(i).Interface()
 		}
 		return append([]any{v}, nl...), nil
@@ -100,7 +100,7 @@ func mustChunk(size int, list any) ([][]any, error) {
 			return nil, fmt.Errorf("number of chunks %d exceeds maximum limit of %d", numChunks, sliceSizeLimit)
 		}
 		result := make([][]any, numChunks)
-		for i := 0; i < numChunks; i++ {
+		for i := range numChunks {
 			clen := size
 			// Handle the last chunk which might be smaller
 			if i == numChunks-1 {
@@ -110,7 +110,7 @@ func mustChunk(size int, list any) ([][]any, error) {
 				}
 			}
 			result[i] = make([]any, clen)
-			for j := 0; j < clen; j++ {
+			for j := range clen {
 				ix := i*size + j
 				result[i][j] = l2.Index(ix).Interface()
 			}
@@ -241,7 +241,7 @@ func mustInitial(list any) ([]any, error) {
 			return nil, nil
 		}
 		nl := make([]any, l-1)
-		for i := 0; i < l-1; i++ {
+		for i := range l - 1 {
 			nl[i] = l2.Index(i).Interface()
 		}
 		return nl, nil
@@ -286,7 +286,7 @@ func mustReverse(v any) ([]any, error) {
 		l := l2.Len()
 		// We do not sort in place because the incoming array should not be altered.
 		nl := make([]any, l)
-		for i := 0; i < l; i++ {
+		for i := range l {
 			nl[l-i-1] = l2.Index(i).Interface()
 		}
 		return nl, nil
@@ -316,7 +316,7 @@ func mustCompact(list any) ([]any, error) {
 		l := l2.Len()
 		var nl []any
 		var item any
-		for i := 0; i < l; i++ {
+		for i := range l {
 			item = l2.Index(i).Interface()
 			if !empty(item) {
 				nl = append(nl, item)
@@ -349,7 +349,7 @@ func mustUniq(list any) ([]any, error) {
 		l := l2.Len()
 		var dest []any
 		var item any
-		for i := 0; i < l; i++ {
+		for i := range l {
 			item = l2.Index(i).Interface()
 			if !inList(dest, item) {
 				dest = append(dest, item)
@@ -393,7 +393,7 @@ func mustWithout(list any, omit ...any) ([]any, error) {
 		l := l2.Len()
 		res := []any{}
 		var item any
-		for i := 0; i < l; i++ {
+		for i := range l {
 			item = l2.Index(i).Interface()
 			if !inList(omit, item) {
 				res = append(res, item)
@@ -428,7 +428,7 @@ func mustHas(needle any, haystack any) (bool, error) {
 		l2 := reflect.ValueOf(haystack)
 		var item any
 		l := l2.Len()
-		for i := 0; i < l; i++ {
+		for i := range l {
 			item = l2.Index(i).Interface()
 			if reflect.DeepEqual(needle, item) {
 				return true, nil
@@ -494,7 +494,7 @@ func concat(lists ...any) any {
 		switch tp {
 		case reflect.Slice, reflect.Array:
 			l2 := reflect.ValueOf(list)
-			for i := 0; i < l2.Len(); i++ {
+			for i := range l2.Len() {
 				res = append(res, l2.Index(i).Interface())
 			}
 		default:

--- a/util/sprig/strings.go
+++ b/util/sprig/strings.go
@@ -202,7 +202,7 @@ func strslice(v any) []string {
 		case reflect.Array, reflect.Slice:
 			l := val.Len()
 			b := make([]string, 0, l)
-			for i := 0; i < l; i++ {
+			for i := range l {
 				value := val.Index(i).Interface()
 				if value != nil {
 					b = append(b, strval(value))


### PR DESCRIPTION
Since this project tries to use the latest go version,  I thought it prudent to update some the old for loops what can be converted to using range function.  Language server was giving warnings `for loop can be modernized using range over int`  so I figured I would do some of this cleanup work.
