### PR TITLE
docs: fix healthcheck zombie processes

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -307,6 +307,7 @@ services:
         retries: 3
         start_period: 40s
     restart: unless-stopped
+    init: true # needed, if healthcheck is used. Prevents zombie processes
 ```
 
 If using a non-root user when running the docker version, be sure to chown the server.yml, user.db, and cache.db files and attachments directory to the same uid/gid.


### PR DESCRIPTION
This single line helps me to prevent zombie processes, when I use the healthcheck possibility, mentioned in the docs. I found as well a good technical explanation at [Stackoverflow](https://stackoverflow.com/questions/77105400/docker-compose-hundreds-of-health-check-processes-not-terminated)

The little fix should also resolve #986.