### PR TITLE
fix: show overflow notification action buttons hidden on small screens

### DIFF
--- a/web/src/components/theme.js
+++ b/web/src/components/theme.js
@@ -17,6 +17,13 @@ const baseThemeOptions = {
         },
       },
     },
+    MuiCardActions: {
+      styleOverrides: {
+        root: {
+          overflowX: "auto",
+        },
+      },
+    },
   },
 };
 


### PR DESCRIPTION
Currently, when you are viewing a notification with multiple actions on a smaller screen (like on mobile), sometimes the actions are cropped from the view, making them inaccessible.

This change fixes overflow notification action buttons being hidden on small screens by setting `overflow-x: auto`, so that the user can at least scroll left & right to access the additional actions.

https://github.com/user-attachments/assets/d080ebd9-40c2-4f2e-aa74-d6529ab5c0de
