### PR TITLE
enable pwa share target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS := --jobs=1
 PYTHON := python3
 PIP := pip3
-VERSION := $(shell git describe --tag)
+VERSION := 1111
 COMMIT := $(shell git rev-parse --short HEAD)
 
 .PHONY:

--- a/server/server.go
+++ b/server/server.go
@@ -636,6 +636,16 @@ func (s *Server) handleWebManifest(w http.ResponseWriter, _ *http.Request, _ *vi
 			{SRC: "/static/images/pwa-192x192.png", Sizes: "192x192", Type: "image/png"},
 			{SRC: "/static/images/pwa-512x512.png", Sizes: "512x512", Type: "image/png"},
 		},
+		ShareTarget: &webManifestShareTarget{
+			Action: "/share-target",
+			Method: "POST",
+			Enctype: "multipart/form-data",
+			Params: &webManifestShareParams{
+				Title: "title",
+				Text:  "text",
+				Url:   "url",
+			},
+		},
 	}
 	return s.writeJSONWithContentType(w, response, "application/manifest+json")
 }

--- a/server/types.go
+++ b/server/types.go
@@ -587,10 +587,25 @@ type webManifestResponse struct {
 	BackgroundColor string             `json:"background_color"`
 	ThemeColor      string             `json:"theme_color"`
 	Icons           []*webManifestIcon `json:"icons"`
+	// Optional PWA share_target support
+	ShareTarget     *webManifestShareTarget `json:"share_target,omitempty"`
 }
 
 type webManifestIcon struct {
 	SRC   string `json:"src"`
 	Sizes string `json:"sizes"`
 	Type  string `json:"type"`
+}
+
+type webManifestShareTarget struct {
+	Action string                 `json:"action"`
+	Method string                 `json:"method"`
+	Enctype string                `json:"enctype"`
+	Params *webManifestShareParams `json:"params"`
+}
+
+type webManifestShareParams struct {
+	Title string `json:"title,omitempty"`
+	Text  string `json:"text,omitempty"`
+	Url   string `json:"url,omitempty"`
 }

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "NODE_OPTIONS=\"--enable-source-maps\" vite",
+    "start": "NODE_OPTIONS=\"--enable-source-maps\" vite --host",
     "build": "vite build",
     "serve": "vite preview",
     "format": "prettier . --write",

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -221,6 +221,40 @@ self.addEventListener("notificationclick", (event) => {
   event.waitUntil(handleClick(event));
 });
 
+// Handle incoming Share Target POSTs from installed PWA share action.
+// The share_target in the manifest posts to `/share-target` as a `multipart/form-data` POST.
+// We parse the form and redirect to the app with query params so the client can pick them up.
+self.addEventListener("fetch", (event) => {
+  try {
+    const reqUrl = new URL(event.request.url);
+    if (reqUrl.pathname === "/share-target" && event.request.method === "POST") {
+      event.respondWith(
+        (async () => {
+          try {
+            const formData = await event.request.formData();
+            const title = formData.get("title") || "";
+            const text = formData.get("text") || "";
+            const sharedUrl = formData.get("url") || "";
+            const params = new URLSearchParams();
+            if (title) params.set("share_title", title);
+            if (text) params.set("share_text", text);
+            if (sharedUrl) params.set("share_url", sharedUrl);
+            // todo support files?
+            // redirect to app.html which is the SPA entry used by the service worker
+            const redirectUrl = `/app.html?${params.toString()}`;
+            return Response.redirect(redirectUrl, 303);
+          } catch (e) {
+            return new Response("", { status: 500 });
+          }
+        })()
+      );
+    }
+    // other fetches are not handled here
+  } catch (e) {
+    // ignore malformed urls
+  }
+});
+
 // See https://vite-pwa-org.netlify.app/guide/inject-manifest.html#service-worker-code
 // self.__WB_MANIFEST is the workbox injection point that injects the manifest of the
 // vite dist files and their revision ids, for example:

--- a/web/src/components/App.jsx
+++ b/web/src/components/App.jsx
@@ -104,6 +104,7 @@ const Layout = () => {
   const { account, setAccount } = useContext(AccountContext);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [sendDialogOpenMode, setSendDialogOpenMode] = useState("");
+  const [sharePayload, setSharePayload] = useState(null);
   const users = useLiveQuery(() => userManager.all());
   const subscriptions = useLiveQuery(() => subscriptionManager.all());
   const webPushTopics = useWebPushTopics();
@@ -119,6 +120,29 @@ const Layout = () => {
   useAccountListener(setAccount);
   useBackgroundProcesses();
   useEffect(() => updateTitle(newNotificationsCount), [newNotificationsCount]);
+
+  // Check URL for share-target params inserted by the service worker redirect
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const title = params.get("share_title");
+      const text = params.get("share_text");
+      const url = params.get(" share_url");
+      if (title || text || url) {
+        const payload = {
+          title: title || undefined,
+          message: text || undefined,
+          url: url || undefined,
+        };
+        setSharePayload(payload);
+        setSendDialogOpenMode(PublishDialog.OPEN_MODE_DEFAULT);
+        // remove params to avoid repeated triggers
+        window.history.replaceState({}, document.title, window.location.pathname + window.location.hash);
+      }
+    } catch (e) {
+      // ignore
+    }
+  }, []);
 
   return (
     <Box sx={{ display: "flex" }}>
@@ -139,7 +163,12 @@ const Layout = () => {
           }}
         />
       </Main>
-      <Messaging selected={selected} dialogOpenMode={sendDialogOpenMode} onDialogOpenModeChange={setSendDialogOpenMode} />
+      <Messaging
+        selected={selected}
+        dialogOpenMode={sendDialogOpenMode}
+        onDialogOpenModeChange={setSendDialogOpenMode}
+        sharePayload={sharePayload}
+      />
     </Box>
   );
 };

--- a/web/src/components/Messaging.jsx
+++ b/web/src/components/Messaging.jsx
@@ -53,7 +53,9 @@ const Messaging = (props) => {
         openMode={dialogOpenMode}
         baseUrl={subscription?.baseUrl ?? config.base_url}
         topic={subscription?.topic ?? ""}
-        message={message}
+        message={props.sharePayload?.message ?? message}
+        title={props.sharePayload?.title}
+        clickUrl={props.sharePayload?.url}
         attachFile={attachFile}
         getPastedImage={getPastedImage}
         onClose={handleDialogClose}

--- a/web/src/components/PublishDialog.jsx
+++ b/web/src/components/PublishDialog.jsx
@@ -109,6 +109,18 @@ const PublishDialog = (props) => {
     setMessage(props.message);
   }, [props.message]);
 
+  useEffect(() => {
+    if (typeof props.title !== "undefined") {
+      setTitle(props.title || "");
+    }
+  }, [props.title]);
+
+  useEffect(() => {
+    if (typeof props.clickUrl !== "undefined") {
+      setClickUrl(props.clickUrl || "");
+    }
+  }, [props.clickUrl]);
+
   const updateBaseUrl = (newVal) => {
     if (validUrl(newVal)) {
       setBaseUrl(newVal.replace(/\/$/, "")); // strip traililng slash after https?://


### PR DESCRIPTION
- adds share_target property to manifest with title + text + url
- configure to send POST to new url , /share-target
  - going with POST so that files can be shared in the future -> https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/share_target#receiving_shared_files
- updated webworker to intercept fetch requests, and redirect+restructure /share-target requests to SPA page with parameters moved to the url params

 (mostly generated by gpt5 using
"i want to add a pwa share target that invokes the publish message button on the web app")


note: I am unable to currently build the docker container to fully test the e2e flow due to 


````
25.40 cmd/serve.go:22:2: no required module provides package heckel.io/ntfy/v2/payments; to add it:
25.40   go get heckel.io/ntfy/v2/payments
25.42 make: *** [Makefile:188: cli-linux-server] Error 1
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
Dockerfile-build:43
--------------------
  41 |     ADD ./user ./user
  42 |     ADD ./util ./util
  43 | >>> RUN make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server
````

running the web client with the npm start command, I was able to verify that url params are successfully read from the url and the publish message opened with the expected values.

what would be the best test command(s) to get the server + web assets deployed locally together?


implements https://github.com/binwiederhier/ntfy/issues/1423