### PR TITLE
do not build fbsend with nofirebase

### DIFF
--- a/tools/fbsend/main.go
+++ b/tools/fbsend/main.go
@@ -1,3 +1,5 @@
+//go:build !nofirebase
+
 package main
 
 import (


### PR DESCRIPTION
The nofirebase build tag should remove all build dependencies on firebase.  The fbsend test tool depends on firebase (and is also only useful in builds that use firebase).  Hence, disable it.