### PR TITLE
do not escape JSON response

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1271,7 +1271,9 @@ func (s *Server) handleBodyAsAttachment(r *http.Request, v *visitor, m *message,
 func (s *Server) handleSubscribeJSON(w http.ResponseWriter, r *http.Request, v *visitor) error {
 	encoder := func(msg *message) (string, error) {
 		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(&msg); err != nil {
+		encoder := json.NewEncoder(&buf)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(&msg); err != nil {
 			return "", err
 		}
 		return buf.String(), nil
@@ -1282,7 +1284,9 @@ func (s *Server) handleSubscribeJSON(w http.ResponseWriter, r *http.Request, v *
 func (s *Server) handleSubscribeSSE(w http.ResponseWriter, r *http.Request, v *visitor) error {
 	encoder := func(msg *message) (string, error) {
 		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(&msg); err != nil {
+		encoder := json.NewEncoder(&buf)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(&msg); err != nil {
 			return "", err
 		}
 		if msg.Event != messageEvent {
@@ -2116,7 +2120,9 @@ func (s *Server) writeJSON(w http.ResponseWriter, v any) error {
 func (s *Server) writeJSONWithContentType(w http.ResponseWriter, v any, contentType string) error {
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Access-Control-Allow-Origin", s.config.AccessControlAllowOrigin) // CORS, allow cross-origin requests
-	if err := json.NewEncoder(w).Encode(v); err != nil {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(v); err != nil {
 		return err
 	}
 	return nil

--- a/server/server_matrix.go
+++ b/server/server_matrix.go
@@ -165,7 +165,9 @@ func writeMatrixResponse(w http.ResponseWriter, rejectedPushKey string) error {
 		Rejected: rejected,
 	}
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(response); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Apparently, golang's JSON encoder automatically escapes `<`, `&`, and `>` in a JSON response (See https://github.com/golang/go/issues/28453 and https://pkg.go.dev/encoding/json#Encoder.SetEscapeHTML).

This was unexpected to me. It seems like whoever is using the returned ntfy message should choose to escape the data if they want to before they use it, instead of ntfy always escaping the data.

Before the change, `curl -d '&' https://ntfy.sh/test` would return `{..."message":"\u0026"...}`

After the change, `curl -d '&' https://ntfy.sh/test` returns `{..."message":"&"...}`

Fixes #1511 