### PR TITLE
Fix curl command example in Notifications component

### DIFF
--- a/web/src/components/Notifications.jsx
+++ b/web/src/components/Notifications.jsx
@@ -600,7 +600,7 @@ const NoNotifications = (props) => {
       <Paragraph>
         {t("notifications_example")}:<br />
         <tt>
-          {'$ curl -d "Hi" '}
+          {'$ curl -d "Hi" https://'}
           {topicShortUrlResolved}
         </tt>
       </Paragraph>


### PR DESCRIPTION
It seems at least in my testing, no response happens without the `https://` prepended.

for instance:
```
➜  ~ curl -d 'hi' ntfy.example.com/p6r76PFAKE_THINGHtRZ3x
➜  ~ curl -d 'hi' https://ntfy.example.com/p6r76PFAKE_THINGHtRZ3x
{"id":"LURnWXPPmkDM","time":1767634827,"expires":1767678027,"event":"message","topic":"p6r76PFAKE_THINGHtRZ3x","message":"hi"}
```