### PR TITLE
Fix links in contributing.md for development guide and contact to work from project-root-page

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,9 +7,9 @@ translator, or just an enthusiastic user.
 
 If you'd like to contribute code to ntfy:
 
-1. Check out the [development guide](develop.md) to set up your environment
+1. Check out the [development guide](/docs/develop.md) to set up your environment
 2. Look at [open issues](https://github.com/binwiederhier/ntfy/issues) for ideas, or propose your own
-3. For larger features or architectural changes, please reach out on [Discord/Matrix](contact.md) first to discuss 
+3. For larger features or architectural changes, please reach out on [Discord/Matrix](/docs/contact.md) first to discuss 
    before investing significant time
 4. Submit a pull request on GitHub
 


### PR DESCRIPTION
When you click on the links from the Contribution.md file, they work just fine.
If you click on the links from the project-root page, it directs you to a 404-page, since the links are relative.

Fix by making link-URIs absolute (relative to the project-root, I guess that's how Github works) 