### PR TITLE
[docs] Fix typo/syntax error in publish.md

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -2154,7 +2154,7 @@ And the same example using [JSON publishing](#publish-as-json):
         method: 'POST',
         body: JSON.stringify({
             topic: "myhome",
-            message": "Garage door has been open for 15 minutes. Close it?",
+            "message": "Garage door has been open for 15 minutes. Close it?",
             actions: [
               {
                 "action": "http",


### PR DESCRIPTION
<img width="277" height="106" alt="image" src="https://github.com/user-attachments/assets/576067a6-38ea-476d-bb61-a79aeca5ec5f" />

changed `message"` to `"message"` here. (Fixed typo)