### PR TITLE
fix: add payments dir to docker build

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -40,6 +40,7 @@ ADD ./log ./log
 ADD ./server ./server
 ADD ./user ./user
 ADD ./util ./util
+ADD ./payments ./payments
 RUN make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server
 
 FROM alpine


### PR DESCRIPTION
Include the `payments` folder in `Dockerfile-build` so the Docker build can see the `heckel.io/ntfy/v2/payments` package.

Error before this change:

```
cmd/serve.go:21:2: no required module provides package heckel.io/ntfy/v2/payments; to add it:
    go get heckel.io/ntfy/v2/payments
make: *** [Makefile:190: cli-linux-server] Error 1
```