### PR TITLE
Allow overriding `npm` binary in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 MAKEFLAGS := --jobs=1
+NPM := npm
 PYTHON := python3
 PIP := pip3
 VERSION := $(shell git describe --tag)
@@ -137,7 +138,7 @@ web: web-deps web-build
 
 web-build:
 	cd web \
-		&& npm run build \
+		&& $(NPM) run build \
 		&& mv build/index.html build/app.html \
 		&& rm -rf ../server/site \
 		&& mv build ../server/site \
@@ -145,20 +146,20 @@ web-build:
 			../server/site/config.js
 
 web-deps:
-	cd web && npm install
+	cd web && $(NPM) install
 	# If this fails for .svg files, optimize them with svgo
 
 web-deps-update:
-	cd web && npm update
+	cd web && $(NPM) update
 
 web-fmt:
-	cd web && npm run format
+	cd web && $(NPM) run format
 
 web-fmt-check:
-	cd web && npm run format:check
+	cd web && $(NPM) run format:check
 
 web-lint:
-	cd web && npm run lint
+	cd web && $(NPM) run lint
 
 # Main server/client build
 


### PR DESCRIPTION
Similar to #949.

I've noticed that Fedora sometimes ship the `npm` binary under versioned names, most recently [here](https://download.copr.fedorainfracloud.org/results/cyqsimon/ntfysh/fedora-44-aarch64/10118658-ntfysh/builder-live.log) ([archive](https://web.archive.org/web/20260212100022/https://download.copr.fedorainfracloud.org/results/cyqsimon/ntfysh/fedora-44-aarch64/10118658-ntfysh/builder-live.log)). In Fedora 44 (pre-release) as of time of writing, the `nodejs-npm` package is an alias of `nodejs22-npm`, which installs `npm` as `/usr/bin/npm-22`.

Anyways, it would be nice if such cases can be dealt with easily.