### PR TITLE
Add comment for zsh users in the terminal example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -661,6 +661,8 @@ Add the following function and alias to your `.bashrc` or `.bash_profile`:
        local token=$(< ~/.ntfy_token)  # Securely read the token
        local status_icon="$([ $exit_status -eq 0 ] && echo magic_wand || echo warning)"
        local last_command=$(history | tail -n1 | sed -e 's/^[[:space:]]*[0-9]\{1,\}[[:space:]]*//' -e 's/[;&|][[:space:]]*alert$//')
+       # for zsh users, use the same sed pattern but get the history differently.
+       # local last_command=$(history "$HISTCMD" | sed -e 's/^[[:space:]]*[0-9]\{1,\}[[:space:]]*//' -e 's/[;&|][[:space:]]*alert$//')
 
        curl -s -X POST "https://n.example.dev/alerts" \
            -H "Authorization: Bearer $token" \


### PR DESCRIPTION
Bash and Zsh terminals' history works slightly different. In bash, the current command is in the history already. In zsh, the history command does not have the currently running command in it.  But it does set the HISTCMD variable to the entry number for the current command. So we can load the current command with `history "$HISTCMD"` in zsh and apply the same sed filter to get the same result as the bash `history | tail -n1` command.

I think it makes more sense to leave this as a comment in the current example than to create a new example, since it otherwise works the exact same.  I've added this to my workflow locally on my Mac and it works great!  It took me a while to figure out the history difference though, so I thought it worth contributing back for zsh users.

Thank you for such a great and flexible piece of software!