### PR TITLE
fix(smtp): preserve <br> line breaks in HTML emails

### DIFF
--- a/server/smtp_server.go
+++ b/server/smtp_server.go
@@ -33,6 +33,7 @@ var (
 var (
 	onlySpacesRegex          = regexp.MustCompile(`(?m)^\s+$`)
 	consecutiveNewLinesRegex = regexp.MustCompile(`\n{3,}`)
+	htmlLineBreakRegex       = regexp.MustCompile(`(?i)<br\s*/?>`)
 )
 
 const (
@@ -327,6 +328,9 @@ func readHTMLMailBody(reader io.Reader, transferEncoding string) (string, error)
 	if err != nil {
 		return "", err
 	}
+	// Convert <br> tags to newlines before stripping HTML, so that line breaks
+	// in HTML emails (e.g. from Synology DSM, and other appliances) are preserved.
+	body = htmlLineBreakRegex.ReplaceAllString(body, "\n")
 	stripped := bluemonday.
 		StrictPolicy().
 		AddSpaceWhenStrippingTag(true).


### PR DESCRIPTION
## Context
HTML-only emails (e.g. from Synology DSM 7.3 Task Scheduler) use `<br>` tags for line breaks. The existing implementation passed the raw HTML body to bluemonday with `AddSpaceWhenStrippingTag(true)`, which replaces every tag including `<br>` with a space. This caused all notification content to appear on a single unreadable line.

## The ntfy notification before the fix
Task Scheduler has completed a scheduled task.  Task: daily-backup  Start time: Mon, 01 Jan 2026 02:00:00 +0000  Current status: 0 (Normal)  From MyNAS

## The ntfy notification after the fix
Task Scheduler has completed a scheduled task.

Task: daily-backup
Start time: Mon, 01 Jan 2026 02:00:00 +0000
Current status: 0 (Normal)

From MyNAS

## Steps to reproduce
```bash
# Start ntfy with SMTP enabled
ntfy serve --smtp-server-listen :25 --smtp-server-domain example.com

# Send an HTML-only email with <br> line breaks
swaks \
  --server 127.0.0.1 --port 25 \
  --from sender@example.com \
  --to ntfy-mytopic@example.com \
  --header "Content-Type: text/html; charset=utf-8" \
  --body "Line one.<BR>Line two.<BR><BR>Line three."

# Check the notification — all text appears on one line:
#    "Line one. Line two.  Line three."
```

## Root cause

The `readHTMLMailBody()` function used `bluemonday.StrictPolicy().AddSpaceWhenStrippingTag(true)` which replaces  all tags including `<br>` with spaces, discarding line break semantics.

## Fix

Convert `<br>` tags to newlines before passing to bluemonday. The regex covers all variants: `<br>`, `<BR>`, `<br/>`, `<BR />`.

## Tests

- Updated `TestSmtpBackend_HTMLOnly_FromDiskStation` and `TestSmtpBackend_HTMLEmail` to reflect correct output
- Added `TestSmtpBackend_HTMLEmail_BrTagsPreserved` covering the Synology Task Scheduler email format

Related to #690