### PR TITLE
Restore VirtualHost Example for Apache HTTP Server 2.4.46 and Earlier

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1385,7 +1385,7 @@ or the root domain:
     }
     ```
 
-=== "Apache2"
+=== "Apache >= 2.4.47"
     ```
     # /etc/apache2/sites-*/ntfy.conf
 
@@ -1393,6 +1393,7 @@ or the root domain:
         ServerName ntfy.sh
 
         # Proxy connections to ntfy (requires "a2enmod proxy proxy_http")
+        # Use mod_proxy_http for websocket upgrade ('upgrade=websocket'), which requires Apache (httpd) >= 2.4.47.
         ProxyPass / http://127.0.0.1:2586/ upgrade=websocket
         ProxyPassReverse / http://127.0.0.1:2586/
 
@@ -1419,8 +1420,71 @@ or the root domain:
         Include /etc/letsencrypt/options-ssl-apache.conf
 
         # Proxy connections to ntfy (requires "a2enmod proxy proxy_http")
+        # Use mod_proxy_http for websocket upgrade ('upgrade=websocket'), which requires Apache (httpd) >= 2.4.47.
         ProxyPass / http://127.0.0.1:2586/ upgrade=websocket
         ProxyPassReverse / http://127.0.0.1:2586/
+
+        SetEnv proxy-nokeepalive 1
+        SetEnv proxy-sendchunked 1
+
+        # Higher than the max message size of 4096 bytes 
+        LimitRequestBody 102400
+	
+    </VirtualHost>
+    ```
+
+=== "Apache < 2.4.47"
+    ```
+    # /etc/apache2/sites-*/ntfy.conf
+
+    <VirtualHost *:80>
+        ServerName ntfy.sh
+
+        # Proxy connections to ntfy (requires "a2enmod proxy")
+        ProxyPass / http://127.0.0.1:2586/
+        ProxyPassReverse / http://127.0.0.1:2586/
+
+        # Enable mod_rewrite (requires "a2enmod rewrite")
+        RewriteEngine on
+        # WebSockets support (requires "a2enmod proxy_wstunnel")
+        # mod_proxy_wstunnel is deprecated as of Apache (httpd) 2.4.47. It also uses more resources since it relies on mod_rewrite.
+        RewriteCond %{HTTP:Upgrade} websocket [NC]
+        RewriteCond %{HTTP:Connection} upgrade [NC]
+        RewriteRule ^/?(.*) "ws://127.0.0.1:2586/$1" [P,L]
+
+        SetEnv proxy-nokeepalive 1
+        SetEnv proxy-sendchunked 1
+
+        # Higher than the max message size of 4096 bytes
+        LimitRequestBody 102400
+        
+        # Redirect HTTP to HTTPS, but only for GET topic addresses, since we want 
+        # it to work with curl without the annoying https:// prefix (requires "a2enmod alias")
+        <If "%{REQUEST_METHOD} == 'GET'">
+            RedirectMatch permanent "^/([-_A-Za-z0-9]{0,64})$" "https://%{SERVER_NAME}/$1"
+        </If>
+
+    </VirtualHost>
+    
+    <VirtualHost *:443>
+        ServerName ntfy.sh
+        
+        SSLEngine on
+        SSLCertificateFile /etc/letsencrypt/live/ntfy.sh/fullchain.pem
+        SSLCertificateKeyFile /etc/letsencrypt/live/ntfy.sh/privkey.pem
+        Include /etc/letsencrypt/options-ssl-apache.conf
+
+        # Proxy connections to ntfy (requires "a2enmod proxy")
+        ProxyPass / http://127.0.0.1:2586/
+        ProxyPassReverse / http://127.0.0.1:2586/
+
+        # Enable mod_rewrite (requires "a2enmod rewrite")
+        RewriteEngine on
+        # WebSockets support (requires "a2enmod proxy_wstunnel")
+        # mod_proxy_wstunnel is deprecated as of Apache (httpd) 2.4.47. It also uses more resources since it relies on mod_rewrite.
+        RewriteCond %{HTTP:Upgrade} websocket [NC]
+        RewriteCond %{HTTP:Connection} upgrade [NC]
+        RewriteRule ^/?(.*) "ws://127.0.0.1:2586/$1" [P,L]
 
         SetEnv proxy-nokeepalive 1
         SetEnv proxy-sendchunked 1


### PR DESCRIPTION
In commit 76667ffc the VirtualHost example configuration was adapted to use the latest ProxyPass parameter 'upgrade'. Restore the previous example for Apache HTTP Server 2.4.46 and earlier, which do not have this function yet without replacing the more current solution, but having both side-by-side. 

https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#protoupgrade