### PR TITLE
Allow edited access tokens to be set to never expire

### DIFF
--- a/server/server_account_test.go
+++ b/server/server_account_test.go
@@ -361,6 +361,15 @@ func TestAccount_ExtendToken(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, "some label", token.Label)
 		require.Equal(t, expires.Unix(), token.Expires)
+
+		body = fmt.Sprintf(`{"token":"%s", "expires": 0}`, token.Token)
+		rr = request(t, s, "PATCH", "/v1/account/token", body, map[string]string{
+			"Authorization": util.BearerAuth(token.Token),
+		})
+		require.Equal(t, 200, rr.Code)
+		token, err = util.UnmarshalJSON[apiAccountTokenResponse](io.NopCloser(rr.Body))
+		require.Nil(t, err)
+		require.Equal(t, int64(0), token.Expires)
 	})
 }
 

--- a/web/src/app/AccountApi.js
+++ b/web/src/app/AccountApi.js
@@ -137,8 +137,8 @@ class AccountApi {
       token,
       label,
     };
-    if (expires > 0) {
-      body.expires = Math.floor(Date.now() / 1000) + expires;
+    if (expires >= 0) {
+      body.expires = expires > 0 ? Math.floor(Date.now() / 1000) + expires : 0;
     }
     console.log(`[AccountApi] Creating user access token ${url}`);
     await fetchOrThrow(url, {


### PR DESCRIPTION
## Summary

This fixes the web account token editor so an existing token can be changed to never expire.

Before this change, the edit dialog offered a "never" option, but the PATCH request omitted the `expires` field when `0` was selected. The server interpreted that as "leave unchanged", so the expiration could only be moved to a future timestamp, not to no expiration.

Changes included:
- send `expires: 0` from the web client when the edit dialog selects "never"
- add a server regression test covering `PATCH /v1/account/token` with `expires: 0`

Closes #1693.

## Validation

- `git diff --check`
- `cd web && npm ci`
- `cd web && npm run lint -- --ext .js,.jsx ./src/app/AccountApi.js ./src/components/Account.jsx`

Notes:
- The local Go toolchain in this environment is `go1.13`, while the repo declares `go 1.25.0`, so I did not claim a meaningful local `go test` run from this machine.
