### PR TITLE
Avoid crashing /account for tokens without a last access time

### DIFF
--- a/server/server_account_test.go
+++ b/server/server_account_test.go
@@ -361,6 +361,15 @@ func TestAccount_ExtendToken(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, "some label", token.Label)
 		require.Equal(t, expires.Unix(), token.Expires)
+
+		body = fmt.Sprintf(`{"token":"%s", "expires": 0}`, token.Token)
+		rr = request(t, s, "PATCH", "/v1/account/token", body, map[string]string{
+			"Authorization": util.BearerAuth(token.Token),
+		})
+		require.Equal(t, 200, rr.Code)
+		token, err = util.UnmarshalJSON[apiAccountTokenResponse](io.NopCloser(rr.Body))
+		require.Nil(t, err)
+		require.Equal(t, int64(0), token.Expires)
 	})
 }
 

--- a/web/src/app/AccountApi.js
+++ b/web/src/app/AccountApi.js
@@ -137,8 +137,8 @@ class AccountApi {
       token,
       label,
     };
-    if (expires > 0) {
-      body.expires = Math.floor(Date.now() / 1000) + expires;
+    if (expires >= 0) {
+      body.expires = expires > 0 ? Math.floor(Date.now() / 1000) + expires : 0;
     }
     console.log(`[AccountApi] Creating user access token ${url}`);
     await fetchOrThrow(url, {

--- a/web/src/components/Account.jsx
+++ b/web/src/components/Account.jsx
@@ -1056,87 +1056,94 @@ const TokensTable = (props) => {
         </TableRow>
       </TableHead>
       <TableBody>
-        {tokens.map((token) => (
-          <TableRow key={token.token} sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
-            <TableCell
-              component="th"
-              scope="row"
-              sx={{ paddingLeft: 0, whiteSpace: "nowrap" }}
-              aria-label={t("account_tokens_table_token_header")}
-            >
-              <span>
-                <span style={{ fontFamily: "Monospace", fontSize: "0.9rem" }}>{token.token.slice(0, 12)}</span>
-                ...
-                <Tooltip title={t("common_copy_to_clipboard")} placement="right">
-                  <IconButton onClick={() => handleCopy(token.token)}>
-                    <ContentCopy />
-                  </IconButton>
-                </Tooltip>
-              </span>
-            </TableCell>
-            <TableCell aria-label={t("account_tokens_table_label_header")}>
-              {token.token === session.token() && <em>{t("account_tokens_table_current_session")}</em>}
-              {token.token !== session.token() && (token.label || "-")}
-            </TableCell>
-            <TableCell sx={{ whiteSpace: "nowrap" }} aria-label={t("account_tokens_table_expires_header")}>
-              {token.expires ? formatShortDateTime(token.expires, i18n.language) : <em>{t("account_tokens_table_never_expires")}</em>}
-            </TableCell>
-            <TableCell sx={{ whiteSpace: "nowrap" }} aria-label={t("account_tokens_table_last_access_header")}>
-              <div style={{ display: "flex", alignItems: "center" }}>
-                <span>{formatShortDateTime(token.last_access, i18n.language)}</span>
-                <Tooltip
-                  title={t("account_tokens_table_last_origin_tooltip", {
-                    ip: token.last_origin,
-                  })}
-                >
-                  <IconButton onClick={() => openUrl(`https://whatismyipaddress.com/ip/${token.last_origin}`)}>
-                    <Public />
-                  </IconButton>
-                </Tooltip>
-              </div>
-            </TableCell>
-            <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-              {token.token !== session.token() && !token.provisioned && (
-                <>
-                  <Tooltip title={t("account_tokens_dialog_title_edit")}>
-                    <IconButton onClick={() => handleEditClick(token)} aria-label={t("account_tokens_dialog_title_edit")}>
-                      <EditIcon />
+        {tokens.map((token) => {
+          const hasLastAccess = Number.isFinite(token.last_access) && token.last_access > 0;
+          const hasLastOrigin = !!token.last_origin;
+
+          return (
+            <TableRow key={token.token} sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
+              <TableCell
+                component="th"
+                scope="row"
+                sx={{ paddingLeft: 0, whiteSpace: "nowrap" }}
+                aria-label={t("account_tokens_table_token_header")}
+              >
+                <span>
+                  <span style={{ fontFamily: "Monospace", fontSize: "0.9rem" }}>{token.token.slice(0, 12)}</span>
+                  ...
+                  <Tooltip title={t("common_copy_to_clipboard")} placement="right">
+                    <IconButton onClick={() => handleCopy(token.token)}>
+                      <ContentCopy />
                     </IconButton>
                   </Tooltip>
-                  <Tooltip title={t("account_tokens_dialog_title_delete")}>
-                    <IconButton onClick={() => handleDeleteClick(token)} aria-label={t("account_tokens_dialog_title_delete")}>
-                      <CloseIcon />
-                    </IconButton>
+                </span>
+              </TableCell>
+              <TableCell aria-label={t("account_tokens_table_label_header")}>
+                {token.token === session.token() && <em>{t("account_tokens_table_current_session")}</em>}
+                {token.token !== session.token() && (token.label || "-")}
+              </TableCell>
+              <TableCell sx={{ whiteSpace: "nowrap" }} aria-label={t("account_tokens_table_expires_header")}>
+                {token.expires ? formatShortDateTime(token.expires, i18n.language) : <em>{t("account_tokens_table_never_expires")}</em>}
+              </TableCell>
+              <TableCell sx={{ whiteSpace: "nowrap" }} aria-label={t("account_tokens_table_last_access_header")}>
+                <div style={{ display: "flex", alignItems: "center" }}>
+                  {hasLastAccess ? <span>{formatShortDateTime(token.last_access, i18n.language)}</span> : <em>-</em>}
+                  {hasLastOrigin && (
+                    <Tooltip
+                      title={t("account_tokens_table_last_origin_tooltip", {
+                        ip: token.last_origin,
+                      })}
+                    >
+                      <IconButton onClick={() => openUrl(`https://whatismyipaddress.com/ip/${token.last_origin}`)}>
+                        <Public />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                {token.token !== session.token() && !token.provisioned && (
+                  <>
+                    <Tooltip title={t("account_tokens_dialog_title_edit")}>
+                      <IconButton onClick={() => handleEditClick(token)} aria-label={t("account_tokens_dialog_title_edit")}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title={t("account_tokens_dialog_title_delete")}>
+                      <IconButton onClick={() => handleDeleteClick(token)} aria-label={t("account_tokens_dialog_title_delete")}>
+                        <CloseIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </>
+                )}
+                {token.token === session.token() && (
+                  <Tooltip title={t("account_tokens_table_cannot_delete_or_edit")}>
+                    <span>
+                      <IconButton disabled>
+                        <EditIcon />
+                      </IconButton>
+                      <IconButton disabled>
+                        <CloseIcon />
+                      </IconButton>
+                    </span>
                   </Tooltip>
-                </>
-              )}
-              {token.token === session.token() && (
-                <Tooltip title={t("account_tokens_table_cannot_delete_or_edit")}>
-                  <span>
-                    <IconButton disabled>
-                      <EditIcon />
-                    </IconButton>
-                    <IconButton disabled>
-                      <CloseIcon />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              )}
-              {token.provisioned && (
-                <Tooltip title={t("account_tokens_table_cannot_delete_or_edit_provisioned_token")}>
-                  <span>
-                    <IconButton disabled>
-                      <EditIcon />
-                    </IconButton>
-                    <IconButton disabled>
-                      <CloseIcon />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              )}
-            </TableCell>
-          </TableRow>
-        ))}
+                )}
+                {token.provisioned && (
+                  <Tooltip title={t("account_tokens_table_cannot_delete_or_edit_provisioned_token")}>
+                    <span>
+                      <IconButton disabled>
+                        <EditIcon />
+                      </IconButton>
+                      <IconButton disabled>
+                        <CloseIcon />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                )}
+              </TableCell>
+            </TableRow>
+          );
+        })}
       </TableBody>
       <Portal>
         <Snackbar


### PR DESCRIPTION
## Summary
- avoid formatting missing `last_access` values in the account token table
- show a placeholder for never-used tokens instead of crashing the entire account page
- only render the IP lookup action when a token actually has a last origin

Fixes #1651
Fixes #1684

## Validation
- npm run lint -- --ext .js,.jsx ./src/components/Account.jsx
- npm run build