### PR TITLE
Include Darwin in the serve Unix build

### DIFF
--- a/cmd/serve_unix.go
+++ b/cmd/serve_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || dragonfly || freebsd || netbsd || openbsd
+//go:build darwin || linux || dragonfly || freebsd || netbsd || openbsd
 
 package cmd
 


### PR DESCRIPTION
## Summary
- include macOS in the Unix serve implementation so Darwin builds get `maybeRunAsService` and `sigHandlerConfigReload`
- keep the change minimal by extending the existing non-Windows build tag instead of introducing a separate Darwin stub

Fixes #1631

## Validation
- git diff --check
- attempted local `go build .` validation on darwin after creating temporary placeholder embed dirs for `server/docs` and `server/site`

## Notes
- the current checkout is missing embedded `server/docs` and `server/site` content, so the local build cannot complete end-to-end without temporary placeholders
- the underlying compile issue from #1631 is addressed by making `cmd/serve_unix.go` build on Darwin as well