### PR TITLE
Read full stdin when publishing

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -123,6 +123,8 @@ func execPublish(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	// Stream redirected stdin directly instead of buffering it into memory first.
+	useStdinMessage := file == "" && message == "" && isStdinRedirected()
 	var options []client.PublishOption
 	if title != "" {
 		options = append(options, client.WithTitle(title))
@@ -196,20 +198,24 @@ func execPublish(c *cli.Context) error {
 		newMessage, err := waitForProcess(pid)
 		if err != nil {
 			return err
-		} else if message == "" {
+		} else if message == "" && !useStdinMessage {
 			message = newMessage
 		}
 	} else if len(command) > 0 {
 		newMessage, err := runAndWaitForCommand(command)
 		if err != nil {
 			return err
-		} else if message == "" {
+		} else if message == "" && !useStdinMessage {
 			message = newMessage
 		}
 	}
 	var body io.Reader
 	if file == "" {
-		body = strings.NewReader(message)
+		if useStdinMessage {
+			body = c.App.Reader
+		} else {
+			body = strings.NewReader(message)
+		}
 	} else {
 		if message != "" {
 			options = append(options, client.WithMessage(message))
@@ -265,15 +271,6 @@ func parseTopicMessageCommand(c *cli.Context) (topic string, message string, com
 	}
 	if c.String("message") != "" {
 		message = c.String("message")
-	}
-	if message == "" && isStdinRedirected() {
-		var data []byte
-		data, err = io.ReadAll(io.LimitReader(c.App.Reader, 1024*1024))
-		if err != nil {
-			log.Debug("Failed to read from stdin: %s", err.Error())
-			return
-		}
-		message = strings.TrimSpace(string(data))
 	}
 	return
 }

--- a/cmd/publish_test.go
+++ b/cmd/publish_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,6 +51,39 @@ func TestCLI_Publish_Subscribe_Poll(t *testing.T) {
 	require.Nil(t, app2.Run([]string{"ntfy", "subscribe", "--poll", topic}))
 	m = toMessage(t, stdout.String())
 	require.Equal(t, "some message", m.Message)
+}
+
+func TestCLI_Publish_Stdin_ReadsFullInput(t *testing.T) {
+	input := strings.Repeat("x", 1024*1024+123)
+	var received int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		received = len(body)
+
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(`{"id":"abc","time":1,"event":"message","topic":"mytopic","message":"ok"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	app, stdin, stdout, _ := newTestApp()
+	_, err := stdin.WriteString(input)
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp(t.TempDir(), "stdin")
+	require.NoError(t, err)
+	oldStdin := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		require.NoError(t, f.Close())
+	})
+
+	require.NoError(t, app.Run([]string{"ntfy", "publish", server.URL + "/mytopic"}))
+	require.Equal(t, len(input), received)
+	require.Contains(t, stdout.String(), `"message":"ok"`)
 }
 
 func TestCLI_Publish_All_The_Things(t *testing.T) {


### PR DESCRIPTION
Fixes #1677.\n\n previously truncated redirected stdin at 1 MiB before sending the request. That closed the pipe early and could kill upstream producers with a broken pipe once the payload exceeded the hardcoded cap.\n\nThis removes the premature cap so redirected stdin is consumed in full, and adds a regression test that verifies the entire payload reaches the server.