### PR TITLE
Fix --wait-pid for processes owned by other users

### DIFF
--- a/cmd/publish_unix.go
+++ b/cmd/publish_unix.go
@@ -2,9 +2,15 @@
 
 package cmd
 
-import "syscall"
+import (
+	"errors"
+	"syscall"
+)
 
 func processExists(pid int) bool {
 	err := syscall.Kill(pid, syscall.Signal(0))
-	return err == nil
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
 }

--- a/docs/subscribe/cli.md
+++ b/docs/subscribe/cli.md
@@ -111,7 +111,7 @@ Or, if you already started the long-running process and want to wait for it usin
 
 === "Using a `pidof`"
     ```
-    $ ntfy pub --wait-pid $(pidof rsync) mytopic | jq .
+    $ ntfy pub --wait-pid $(pidof -s rsync) mytopic | jq .
     {
       "id": "orM6hJKNYkWb",
       "time": 1655825827,


### PR DESCRIPTION
Two small fixes around `ntfy pub --wait-pid`.

### 1. `processExists` treats EPERM as "gone" (cmd/publish_unix.go)

`kill(pid, 0)` returns `nil` on success, `ESRCH` if the PID doesn't
exist, and `EPERM` if it exists but the caller can't signal it. The
current code treats any error as "doesn't exist", so `--wait-pid`
exits immediately when the target process belongs to another user.

**Repro (before):** as a regular user, against a root-owned process:

```
sudo sleep 300 &
ntfy pub --wait-pid $(pidof -s sleep) mytopic "done"
# -> "process with PID ... not running"  (wrong -- it's very much running)
```

After the fix, `--wait-pid` correctly blocks until the process exits.

Real-world case: `ntfy` running as a regular user waiting on a
root-owned `restic` backup.

### 2. `pidof` example uses `-s` (docs/subscribe/cli.md)

`pidof rsync` returns space-separated PIDs when multiple processes
match, which breaks `--wait-pid`'s single-integer argument. `pidof -s`
(single-shot) returns just one.