### PR TITLE
Fix opening links with noreferrer

### DIFF
--- a/web/src/app/utils.js
+++ b/web/src/app/utils.js
@@ -178,7 +178,7 @@ export const formatPrice = (n) => {
 };
 
 export const openUrl = (url) => {
-  window.open(url, "_blank", "noopener,noreferrer");
+  window.open(url, "_blank", "noreferrer");
 };
 
 export const sounds = {

--- a/web/src/components/Notifications.jsx
+++ b/web/src/components/Notifications.jsx
@@ -164,7 +164,7 @@ const autolink = (s) => {
   const parts = s.split(/(\bhttps?:\/\/[-A-Z0-9+\u0026\u2019@#/%?=()~_|!:,.;]*[-A-Z0-9+\u0026@#/%=~()_|]\b)/gi);
   for (let i = 1; i < parts.length; i += 2) {
     parts[i] = (
-      <Link key={i} href={parts[i]} underline="hover" target="_blank" rel="noreferrer,noopener">
+      <Link key={i} href={parts[i]} underline="hover" target="_blank" rel="noreferrer">
         {shortUrl(parts[i])}
       </Link>
     );


### PR DESCRIPTION
`rel="noreferrer"` has the same effect as `rel="noopener"`, but also prevents the `Referer` header from being sent to the new page.
https://mui.com/material-ui/react-link/#security

If this feature is set, the browser will omit the `Referer` header, as well as set `noopener` to true.
https://developer.mozilla.org/en-US/docs/Web/API/Window/open#noreferrer

**Changes**
Drop `noopener` if `noreferrer` is set.

**Issues**
N/A
The `Referer` header is sent to the server.

**Notes**
The value of the `rel` attribute must be space-separated.
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel