### PR TITLE
Add X-Persist header to control client-side local storage

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -47,6 +47,7 @@ type Message struct {
 	PollID      string      `json:"poll_id,omitempty"`
 	ContentType string      `json:"content_type,omitempty"` // text/plain by default (if empty), or text/markdown
 	Encoding    string      `json:"encoding,omitempty"`     // Empty for raw UTF-8, or "base64" for encoded bytes
+	Persist     *bool       `json:"persist,omitempty"`      // If false, clients should not save the message to local history
 	Sender      netip.Addr  `json:"-"`                      // IP address of uploader, used for rate limiting
 	User        string      `json:"-"`                      // UserID of the uploader, used to associated attachments
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1166,6 +1166,7 @@ func (s *Server) parsePublishParams(r *http.Request, m *model.Message) (cache bo
 		}
 	}
 	cache = readBoolParam(r, true, "x-cache", "cache")
+	m.Persist = readOptionalBoolParam(r, "x-persist", "persist")
 	firebase = readBoolParam(r, true, "x-firebase", "firebase")
 	m.Title = readParam(r, "x-title", "title", "t")
 	m.Click = readParam(r, "x-click", "click")

--- a/server/util.go
+++ b/server/util.go
@@ -30,6 +30,16 @@ var (
 	forwardedHeaderRegex = regexp.MustCompile(`(?i)\bfor="?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-f:]+])(?::\d+)?"?`)
 )
 
+// readOptionalBoolParam returns nil if the param is not set, otherwise a pointer to the parsed bool value.
+func readOptionalBoolParam(r *http.Request, names ...string) *bool {
+	value := strings.ToLower(readParam(r, names...))
+	if value == "" || !isBoolValue(value) {
+		return nil
+	}
+	b := toBool(value)
+	return &b
+}
+
 func readBoolParam(r *http.Request, defaultValue bool, names ...string) bool {
 	value := strings.ToLower(readParam(r, names...))
 	if value == "" {


### PR DESCRIPTION
## Summary

Introduces a new `X-Persist` (or `Persist`) publish parameter. When set to `no`, the server includes `"persist": false` in the broadcast JSON payload, signalling clients that they should not save the message to local history.

This is intentionally **separate from `X-Cache`** (server-side caching) so that publishers can control client persistence independently:

- `X-Cache: no` — server does not cache the message
- `X-Persist: no` — clients should not save the message to local history

A common use case is ephemeral clipboard sync or other transient notifications that should be delivered and shown, but not accumulate in message history.

## Changes

- `model/model.go` — add `Persist *bool` field to `Message` (omitted from JSON when nil)
- `server/util.go` — add `readOptionalBoolParam` helper returning `*bool` (nil when not set)
- `server/server.go` — parse `x-persist`/`persist` header and set `m.Persist`

## Related

Android client support: EugeneShtoka/ntfy-android#1 (respects `"persist": false` to skip local DB insert)