### PR TITLE
Add server-side heartbeat monitor feature

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -111,6 +111,9 @@ var flagsServe = append(
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-startup-queries", Aliases: []string{"web_push_startup_queries"}, EnvVars: []string{"NTFY_WEB_PUSH_STARTUP_QUERIES"}, Usage: "queries run when the web push database is initialized"}),
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-expiry-duration", Aliases: []string{"web_push_expiry_duration"}, EnvVars: []string{"NTFY_WEB_PUSH_EXPIRY_DURATION"}, Value: util.FormatDuration(server.DefaultWebPushExpiryDuration), Usage: "automatically expire unused subscriptions after this time"}),
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "web-push-expiry-warning-duration", Aliases: []string{"web_push_expiry_warning_duration"}, EnvVars: []string{"NTFY_WEB_PUSH_EXPIRY_WARNING_DURATION"}, Value: util.FormatDuration(server.DefaultWebPushExpiryWarningDuration), Usage: "send web push warning notification after this time before expiring unused subscriptions"}),
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "monitor-file", Aliases: []string{"monitor_file"}, EnvVars: []string{"NTFY_MONITOR_FILE"}, Usage: "file used to store heartbeat monitor state (enables the monitor feature)"}),
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "monitor-startup-queries", Aliases: []string{"monitor_startup_queries"}, EnvVars: []string{"NTFY_MONITOR_STARTUP_QUERIES"}, Usage: "queries run when the monitor database is initialized"}),
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "monitor-check-interval", Aliases: []string{"monitor_check_interval"}, EnvVars: []string{"NTFY_MONITOR_CHECK_INTERVAL"}, Value: util.FormatDuration(server.DefaultMonitorCheckInterval), Usage: "how often the heartbeat ticker scans for stale monitors"}),
 )
 
 var cmdServe = &cli.Command{
@@ -155,6 +158,9 @@ func execServe(c *cli.Context) error {
 	webPushStartupQueries := c.String("web-push-startup-queries")
 	webPushExpiryDurationStr := c.String("web-push-expiry-duration")
 	webPushExpiryWarningDurationStr := c.String("web-push-expiry-warning-duration")
+	monitorFile := c.String("monitor-file")
+	monitorStartupQueries := c.String("monitor-startup-queries")
+	monitorCheckIntervalStr := c.String("monitor-check-interval")
 	cacheFile := c.String("cache-file")
 	cacheDurationStr := c.String("cache-duration")
 	cacheStartupQueries := c.String("cache-startup-queries")
@@ -259,6 +265,10 @@ func execServe(c *cli.Context) error {
 	webPushExpiryWarningDuration, err := util.ParseDuration(webPushExpiryWarningDurationStr)
 	if err != nil {
 		return fmt.Errorf("invalid web push expiry warning duration: %s", webPushExpiryWarningDurationStr)
+	}
+	monitorCheckInterval, err := util.ParseDuration(monitorCheckIntervalStr)
+	if err != nil {
+		return fmt.Errorf("invalid monitor check interval: %s", monitorCheckIntervalStr)
 	}
 
 	// Convert sizes to bytes
@@ -521,6 +531,9 @@ func execServe(c *cli.Context) error {
 	conf.WebPushStartupQueries = webPushStartupQueries
 	conf.WebPushExpiryDuration = webPushExpiryDuration
 	conf.WebPushExpiryWarningDuration = webPushExpiryWarningDuration
+	conf.MonitorFile = monitorFile
+	conf.MonitorStartupQueries = monitorStartupQueries
+	conf.MonitorCheckInterval = monitorCheckInterval
 	conf.BuildVersion = c.App.Version
 	conf.BuildDate = maybeFromMetadata(c.App.Metadata, MetadataKeyDate)
 	conf.BuildCommit = maybeFromMetadata(c.App.Metadata, MetadataKeyCommit)

--- a/monitor/manager.go
+++ b/monitor/manager.go
@@ -1,0 +1,173 @@
+package monitor
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+
+	"heckel.io/ntfy/v2/db"
+)
+
+// Manager owns the monitor database connection and exposes CRUD + state operations.
+type Manager struct {
+	db *db.DB
+}
+
+// AddMonitor inserts a new monitor in StatePending. Returns ErrMonitorExists when
+// (user_id, key) already exists.
+func (m *Manager) AddMonitor(userID, key string, periodSeconds, graceSeconds int64, alertTopic string, alertPriority int) (*Monitor, error) {
+	if userID == "" {
+		return nil, ErrInvalidUserID
+	}
+	if err := ValidateKey(key); err != nil {
+		return nil, err
+	}
+	if err := ValidatePeriod(periodSeconds); err != nil {
+		return nil, err
+	}
+	if err := ValidateGrace(graceSeconds); err != nil {
+		return nil, err
+	}
+	if err := ValidateAlertTopic(alertTopic); err != nil {
+		return nil, err
+	}
+	if err := ValidateAlertPriority(alertPriority); err != nil {
+		return nil, err
+	}
+	now := time.Now().Unix()
+	res, err := m.db.Exec(sqliteInsertMonitorQuery, userID, key, periodSeconds, graceSeconds, alertTopic, alertPriority, StatePending, 0, now)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return nil, ErrMonitorExists
+		}
+		return nil, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	return &Monitor{
+		ID:            id,
+		UserID:        userID,
+		Key:           key,
+		PeriodSeconds: periodSeconds,
+		GraceSeconds:  graceSeconds,
+		AlertTopic:    alertTopic,
+		AlertPriority: alertPriority,
+		State:         StatePending,
+		LastSeenAt:    0,
+		CreatedAt:     now,
+	}, nil
+}
+
+// GetMonitor returns the monitor for (userID, key) or ErrMonitorNotFound.
+func (m *Manager) GetMonitor(userID, key string) (*Monitor, error) {
+	row := m.db.ReadOnly().QueryRow(sqliteSelectMonitorByUserAndKeyQuery, userID, key)
+	mon, err := scanMonitor(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrMonitorNotFound
+	}
+	return mon, err
+}
+
+// ListMonitorsByUser returns all monitors owned by userID, sorted by key.
+func (m *Manager) ListMonitorsByUser(userID string) ([]*Monitor, error) {
+	rows, err := m.db.ReadOnly().Query(sqliteSelectMonitorsByUserQuery, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanMonitors(rows)
+}
+
+// DeleteMonitor removes the monitor for (userID, key). Returns ErrMonitorNotFound
+// when nothing was deleted.
+func (m *Manager) DeleteMonitor(userID, key string) error {
+	res, err := m.db.Exec(sqliteDeleteMonitorQuery, userID, key)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrMonitorNotFound
+	}
+	return nil
+}
+
+// RecordHeartbeat marks a heartbeat for (userID, key) and returns the updated monitor along
+// with the previous state. Pending or Down monitors transition to Up. Up monitors stay Up.
+// The caller decides whether to publish an UP recovery alert based on the previous state.
+func (m *Manager) RecordHeartbeat(userID, key string) (mon *Monitor, prevState string, err error) {
+	err = db.ExecTx(m.db, func(tx *sql.Tx) error {
+		row := tx.QueryRow(sqliteSelectMonitorByUserAndKeyQuery, userID, key)
+		current, scanErr := scanMonitor(row)
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return ErrMonitorNotFound
+		} else if scanErr != nil {
+			return scanErr
+		}
+		prevState = current.State
+		now := time.Now().Unix()
+		if _, execErr := tx.Exec(sqliteUpdateMonitorHeartbeatQuery, now, StateUp, current.ID); execErr != nil {
+			return execErr
+		}
+		current.LastSeenAt = now
+		current.State = StateUp
+		mon = current
+		return nil
+	})
+	return mon, prevState, err
+}
+
+// StaleMonitors returns Up monitors whose last_seen_at + period + grace is in the past.
+// Pending monitors are intentionally excluded; they never alert until the first ping arrives.
+func (m *Manager) StaleMonitors() ([]*Monitor, error) {
+	now := time.Now().Unix()
+	rows, err := m.db.ReadOnly().Query(sqliteSelectStaleMonitorsQuery, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanMonitors(rows)
+}
+
+// MarkDown transitions a monitor to StateDown. No-op if the monitor was already Down.
+func (m *Manager) MarkDown(id int64) error {
+	_, err := m.db.Exec(sqliteUpdateMonitorStateQuery, StateDown, id)
+	return err
+}
+
+// SetLastSeenAt overrides last_seen_at for a monitor. Useful for tests and admin tooling.
+// It does not change the monitor state.
+func (m *Manager) SetLastSeenAt(id int64, unixSeconds int64) error {
+	_, err := m.db.Exec(`UPDATE monitor SET last_seen_at = ? WHERE id = ?`, unixSeconds, id)
+	return err
+}
+
+// Close closes the underlying database.
+func (m *Manager) Close() error {
+	return m.db.Close()
+}
+
+func scanMonitor(row interface{ Scan(...any) error }) (*Monitor, error) {
+	var mon Monitor
+	if err := row.Scan(&mon.ID, &mon.UserID, &mon.Key, &mon.PeriodSeconds, &mon.GraceSeconds, &mon.AlertTopic, &mon.AlertPriority, &mon.State, &mon.LastSeenAt, &mon.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &mon, nil
+}
+
+func scanMonitors(rows *sql.Rows) ([]*Monitor, error) {
+	monitors := make([]*Monitor, 0)
+	for rows.Next() {
+		mon, err := scanMonitor(rows)
+		if err != nil {
+			return nil, err
+		}
+		monitors = append(monitors, mon)
+	}
+	return monitors, rows.Err()
+}

--- a/monitor/manager_sqlite.go
+++ b/monitor/manager_sqlite.go
@@ -1,0 +1,130 @@
+package monitor
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3" // SQLite driver
+
+	"heckel.io/ntfy/v2/db"
+	"heckel.io/ntfy/v2/util"
+)
+
+const (
+	sqliteCreateTablesQuery = `
+		CREATE TABLE IF NOT EXISTS monitor (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id TEXT NOT NULL,
+			key TEXT NOT NULL,
+			period_seconds INT NOT NULL,
+			grace_seconds INT NOT NULL,
+			alert_topic TEXT NOT NULL,
+			alert_priority INT NOT NULL DEFAULT 4,
+			state TEXT NOT NULL DEFAULT 'pending',
+			last_seen_at INT NOT NULL DEFAULT 0,
+			created_at INT NOT NULL
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_monitor_user_key ON monitor (user_id, key);
+		CREATE INDEX IF NOT EXISTS idx_monitor_user ON monitor (user_id);
+		CREATE INDEX IF NOT EXISTS idx_monitor_state ON monitor (state);
+		CREATE TABLE IF NOT EXISTS schemaVersion (
+			id INT PRIMARY KEY,
+			version INT NOT NULL
+		);
+	`
+	sqliteBuiltinStartupQueries = `PRAGMA foreign_keys = ON;`
+
+	sqliteInsertMonitorQuery = `
+		INSERT INTO monitor (user_id, key, period_seconds, grace_seconds, alert_topic, alert_priority, state, last_seen_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	sqliteSelectMonitorColumns = `id, user_id, key, period_seconds, grace_seconds, alert_topic, alert_priority, state, last_seen_at, created_at`
+	sqliteSelectMonitorByUserAndKeyQuery = `
+		SELECT ` + sqliteSelectMonitorColumns + `
+		FROM monitor
+		WHERE user_id = ? AND key = ?
+	`
+	sqliteSelectMonitorsByUserQuery = `
+		SELECT ` + sqliteSelectMonitorColumns + `
+		FROM monitor
+		WHERE user_id = ?
+		ORDER BY key
+	`
+	sqliteSelectStaleMonitorsQuery = `
+		SELECT ` + sqliteSelectMonitorColumns + `
+		FROM monitor
+		WHERE state = 'up' AND last_seen_at + period_seconds + grace_seconds < ?
+	`
+	sqliteUpdateMonitorHeartbeatQuery = `UPDATE monitor SET last_seen_at = ?, state = ? WHERE id = ?`
+	sqliteUpdateMonitorStateQuery     = `UPDATE monitor SET state = ? WHERE id = ?`
+	sqliteDeleteMonitorQuery          = `DELETE FROM monitor WHERE user_id = ? AND key = ?`
+)
+
+// SQLite schema management queries
+const (
+	sqliteCurrentSchemaVersion     = 1
+	sqliteInsertSchemaVersionQuery = `INSERT INTO schemaVersion VALUES (1, ?)`
+	sqliteSelectSchemaVersionQuery = `SELECT version FROM schemaVersion WHERE id = 1`
+)
+
+// NewSQLiteManager creates a new Manager backed by a SQLite database file.
+func NewSQLiteManager(filename, startupQueries string) (*Manager, error) {
+	parentDir := filepath.Dir(filename)
+	if !util.FileExists(parentDir) {
+		return nil, fmt.Errorf("monitor database directory %s does not exist or is not accessible", parentDir)
+	}
+	d, err := sql.Open("sqlite3", filename)
+	if err != nil {
+		return nil, err
+	}
+	if err := setupSQLite(d); err != nil {
+		return nil, err
+	}
+	if err := runSQLiteStartupQueries(d, startupQueries); err != nil {
+		return nil, err
+	}
+	return &Manager{db: db.New(&db.Host{DB: d}, nil)}, nil
+}
+
+func setupSQLite(sqlDB *sql.DB) error {
+	var schemaVersion int
+	if err := sqlDB.QueryRow(sqliteSelectSchemaVersionQuery).Scan(&schemaVersion); err != nil {
+		return setupNewSQLite(sqlDB)
+	}
+	if schemaVersion > sqliteCurrentSchemaVersion {
+		return fmt.Errorf("unexpected schema version: version %d is higher than current version %d", schemaVersion, sqliteCurrentSchemaVersion)
+	}
+	return nil
+}
+
+func setupNewSQLite(sqlDB *sql.DB) error {
+	return db.ExecTx(sqlDB, func(tx *sql.Tx) error {
+		if _, err := tx.Exec(sqliteCreateTablesQuery); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(sqliteInsertSchemaVersionQuery, sqliteCurrentSchemaVersion); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func runSQLiteStartupQueries(sqlDB *sql.DB, startupQueries string) error {
+	if _, err := sqlDB.Exec(sqliteBuiltinStartupQueries); err != nil {
+		return err
+	}
+	if startupQueries != "" {
+		if _, err := sqlDB.Exec(startupQueries); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isUniqueConstraintError reports whether err is a SQLite UNIQUE constraint violation.
+// SQLite returns "UNIQUE constraint failed: ..." for these.
+func isUniqueConstraintError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
+}

--- a/monitor/manager_test.go
+++ b/monitor/manager_test.go
@@ -1,0 +1,204 @@
+package monitor
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestManager(t *testing.T) *Manager {
+	m, err := NewSQLiteManager(filepath.Join(t.TempDir(), "monitor.db"), "")
+	require.Nil(t, err)
+	t.Cleanup(func() { m.Close() })
+	return m
+}
+
+func TestManager_AddMonitor_Success(t *testing.T) {
+	m := newTestManager(t)
+	mon, err := m.AddMonitor("u_alice", "scanner", 300, 60, "alerts", DefaultAlertPriority)
+	require.Nil(t, err)
+	require.NotZero(t, mon.ID)
+	require.Equal(t, "u_alice", mon.UserID)
+	require.Equal(t, "scanner", mon.Key)
+	require.Equal(t, int64(300), mon.PeriodSeconds)
+	require.Equal(t, int64(60), mon.GraceSeconds)
+	require.Equal(t, "alerts", mon.AlertTopic)
+	require.Equal(t, DefaultAlertPriority, mon.AlertPriority)
+	require.Equal(t, StatePending, mon.State)
+	require.Zero(t, mon.LastSeenAt)
+	require.NotZero(t, mon.CreatedAt)
+}
+
+func TestManager_AddMonitor_DuplicateKeySameUser(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.AddMonitor("u_alice", "scanner", 300, 60, "alerts", 3)
+	require.Nil(t, err)
+	_, err = m.AddMonitor("u_alice", "scanner", 300, 60, "alerts", 3)
+	require.ErrorIs(t, err, ErrMonitorExists)
+}
+
+func TestManager_AddMonitor_DuplicateKeyAcrossUsersAllowed(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.AddMonitor("u_alice", "scanner", 300, 60, "alerts", 3)
+	require.Nil(t, err)
+	_, err = m.AddMonitor("u_bob", "scanner", 300, 60, "alerts", 3)
+	require.Nil(t, err)
+}
+
+func TestManager_AddMonitor_Validation(t *testing.T) {
+	m := newTestManager(t)
+	cases := []struct {
+		name    string
+		userID  string
+		key     string
+		period  int64
+		grace   int64
+		topic   string
+		prio    int
+		wantErr error
+	}{
+		{"empty user", "", "k", 60, 30, "alerts", 3, ErrInvalidUserID},
+		{"bad key", "u_a", "bad/key", 60, 30, "alerts", 3, ErrInvalidKey},
+		{"period too small", "u_a", "k", 1, 30, "alerts", 3, ErrInvalidPeriod},
+		{"period too large", "u_a", "k", 1_000_000, 30, "alerts", 3, ErrInvalidPeriod},
+		{"grace too small", "u_a", "k", 60, 0, "alerts", 3, ErrInvalidGrace},
+		{"grace too large", "u_a", "k", 60, 1_000_000, "alerts", 3, ErrInvalidGrace},
+		{"bad topic", "u_a", "k", 60, 30, "bad/topic", 3, ErrInvalidAlertTopic},
+		{"prio too low", "u_a", "k", 60, 30, "alerts", 0, ErrInvalidAlertPriority},
+		{"prio too high", "u_a", "k", 60, 30, "alerts", 6, ErrInvalidAlertPriority},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := m.AddMonitor(tc.userID, tc.key, tc.period, tc.grace, tc.topic, tc.prio)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestManager_GetMonitor_NotFound(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.GetMonitor("u_nobody", "ghost")
+	require.ErrorIs(t, err, ErrMonitorNotFound)
+}
+
+func TestManager_GetMonitor_RoundTrip(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.AddMonitor("u_alice", "scanner", 300, 60, "alerts", 4)
+	require.Nil(t, err)
+	got, err := m.GetMonitor("u_alice", "scanner")
+	require.Nil(t, err)
+	require.Equal(t, "scanner", got.Key)
+	require.Equal(t, "u_alice", got.UserID)
+}
+
+func TestManager_ListMonitorsByUser_ScopedAndSorted(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.AddMonitor("u_alice", "z", 60, 30, "a", 3)
+	require.Nil(t, err)
+	_, err = m.AddMonitor("u_alice", "a", 60, 30, "a", 3)
+	require.Nil(t, err)
+	_, err = m.AddMonitor("u_bob", "x", 60, 30, "a", 3)
+	require.Nil(t, err)
+
+	list, err := m.ListMonitorsByUser("u_alice")
+	require.Nil(t, err)
+	require.Len(t, list, 2)
+	require.Equal(t, "a", list[0].Key)
+	require.Equal(t, "z", list[1].Key)
+}
+
+func TestManager_DeleteMonitor(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.AddMonitor("u_alice", "scanner", 60, 30, "a", 3)
+	require.Nil(t, err)
+	require.Nil(t, m.DeleteMonitor("u_alice", "scanner"))
+	_, err = m.GetMonitor("u_alice", "scanner")
+	require.ErrorIs(t, err, ErrMonitorNotFound)
+	require.ErrorIs(t, m.DeleteMonitor("u_alice", "scanner"), ErrMonitorNotFound)
+}
+
+func TestManager_RecordHeartbeat_PendingToUp(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.AddMonitor("u_alice", "scanner", 60, 30, "alerts", 3)
+	require.Nil(t, err)
+
+	mon, prev, err := m.RecordHeartbeat("u_alice", "scanner")
+	require.Nil(t, err)
+	require.Equal(t, StatePending, prev)
+	require.Equal(t, StateUp, mon.State)
+	require.NotZero(t, mon.LastSeenAt)
+}
+
+func TestManager_RecordHeartbeat_UpStaysUp(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.AddMonitor("u_alice", "scanner", 60, 30, "alerts", 3)
+	require.Nil(t, err)
+	_, _, err = m.RecordHeartbeat("u_alice", "scanner")
+	require.Nil(t, err)
+
+	_, prev, err := m.RecordHeartbeat("u_alice", "scanner")
+	require.Nil(t, err)
+	require.Equal(t, StateUp, prev) // already up
+}
+
+func TestManager_RecordHeartbeat_DownToUp(t *testing.T) {
+	m := newTestManager(t)
+	mon, err := m.AddMonitor("u_alice", "scanner", 60, 30, "alerts", 3)
+	require.Nil(t, err)
+	require.Nil(t, m.MarkDown(mon.ID))
+
+	_, prev, err := m.RecordHeartbeat("u_alice", "scanner")
+	require.Nil(t, err)
+	require.Equal(t, StateDown, prev) // caller should fire UP recovery alert
+}
+
+func TestManager_RecordHeartbeat_NotFound(t *testing.T) {
+	m := newTestManager(t)
+	_, _, err := m.RecordHeartbeat("u_alice", "ghost")
+	require.ErrorIs(t, err, ErrMonitorNotFound)
+}
+
+func TestManager_StaleMonitors_ExcludesPendingAndDown(t *testing.T) {
+	m := newTestManager(t)
+	// Pending monitor — never alerts even though "overdue"
+	_, err := m.AddMonitor("u_alice", "pending-one", 60, 30, "a", 3)
+	require.Nil(t, err)
+
+	// Down monitor — already alerted, should not appear again
+	down, err := m.AddMonitor("u_alice", "down-one", 60, 30, "a", 3)
+	require.Nil(t, err)
+	require.Nil(t, m.MarkDown(down.ID))
+
+	// Up monitor with stale last_seen — should appear
+	up, err := m.AddMonitor("u_alice", "up-stale", 60, 30, "a", 3)
+	require.Nil(t, err)
+	_, _, err = m.RecordHeartbeat("u_alice", "up-stale")
+	require.Nil(t, err)
+	// Backdate last_seen so now > last_seen + period + grace
+	_, err = m.db.Exec(`UPDATE monitor SET last_seen_at = ? WHERE id = ?`, time.Now().Unix()-200, up.ID)
+	require.Nil(t, err)
+
+	// Up monitor with fresh last_seen — should NOT appear
+	fresh, err := m.AddMonitor("u_alice", "up-fresh", 60, 30, "a", 3)
+	require.Nil(t, err)
+	_, _, err = m.RecordHeartbeat("u_alice", "up-fresh")
+	require.Nil(t, err)
+	_ = fresh
+
+	stale, err := m.StaleMonitors()
+	require.Nil(t, err)
+	require.Len(t, stale, 1)
+	require.Equal(t, "up-stale", stale[0].Key)
+}
+
+func TestManager_MarkDown(t *testing.T) {
+	m := newTestManager(t)
+	mon, err := m.AddMonitor("u_alice", "scanner", 60, 30, "a", 3)
+	require.Nil(t, err)
+	require.Nil(t, m.MarkDown(mon.ID))
+	got, err := m.GetMonitor("u_alice", "scanner")
+	require.Nil(t, err)
+	require.Equal(t, StateDown, got.State)
+}

--- a/monitor/types.go
+++ b/monitor/types.go
@@ -1,0 +1,104 @@
+// Package monitor implements heartbeat / dead-man's-switch monitors. A monitor is an authenticated
+// per-user record that expects to receive periodic pings on a heartbeat endpoint. If a ping does
+// not arrive within period+grace, the server publishes a DOWN alert message to the configured
+// alert topic. When pings resume, an UP recovery alert is published.
+package monitor
+
+import (
+	"errors"
+	"regexp"
+)
+
+// Monitor states
+const (
+	StatePending = "pending" // Created but no heartbeat received yet; never alerts
+	StateUp      = "up"      // Last heartbeat was within period+grace; eligible for DOWN transition
+	StateDown    = "down"    // Missed period+grace since last heartbeat; eligible for UP recovery
+)
+
+// Bounds for monitor configuration. These are sanity caps, not policy.
+const (
+	MinPeriodSeconds = 30
+	MaxPeriodSeconds = 86400 // 24h
+	MinGraceSeconds  = 10
+	MaxGraceSeconds  = 86400
+
+	MinAlertPriority = 1
+	MaxAlertPriority = 5
+
+	DefaultAlertPriority = 4 // High, but not Max
+)
+
+var (
+	// keyRegex must remain in sync with the URL regex in server.go that maps /v1/heartbeat/<key>.
+	keyRegex = regexp.MustCompile(`^[-_A-Za-z0-9]{1,64}$`)
+
+	// alertTopicRegex matches ntfy's topicRegex. Kept independently to avoid a server-package import.
+	alertTopicRegex = regexp.MustCompile(`^[-_A-Za-z0-9]{1,64}$`)
+)
+
+// Errors returned by the Manager.
+var (
+	ErrMonitorNotFound       = errors.New("monitor not found")
+	ErrMonitorExists         = errors.New("monitor already exists")
+	ErrInvalidKey            = errors.New("invalid monitor key")
+	ErrInvalidPeriod         = errors.New("invalid period")
+	ErrInvalidGrace          = errors.New("invalid grace")
+	ErrInvalidAlertTopic     = errors.New("invalid alert topic")
+	ErrInvalidAlertPriority  = errors.New("invalid alert priority")
+	ErrInvalidUserID         = errors.New("invalid user id")
+)
+
+// Monitor is a single heartbeat-tracked entity owned by a user.
+type Monitor struct {
+	ID            int64  // Auto-increment row id
+	UserID        string // Owner; references user.id (no cross-DB FK)
+	Key           string // User-chosen identifier, unique per UserID
+	PeriodSeconds int64  // How often a ping is expected
+	GraceSeconds  int64  // Slack allowed before declaring DOWN
+	AlertTopic    string // ntfy topic to publish DOWN/UP alerts on
+	AlertPriority int    // Priority for alert messages (1-5)
+	State         string // pending | up | down
+	LastSeenAt    int64  // Unix seconds; 0 means never seen
+	CreatedAt     int64  // Unix seconds
+}
+
+// ValidateKey returns ErrInvalidKey if the key is malformed.
+func ValidateKey(key string) error {
+	if !keyRegex.MatchString(key) {
+		return ErrInvalidKey
+	}
+	return nil
+}
+
+// ValidatePeriod returns ErrInvalidPeriod if the period is out of bounds.
+func ValidatePeriod(seconds int64) error {
+	if seconds < MinPeriodSeconds || seconds > MaxPeriodSeconds {
+		return ErrInvalidPeriod
+	}
+	return nil
+}
+
+// ValidateGrace returns ErrInvalidGrace if the grace is out of bounds.
+func ValidateGrace(seconds int64) error {
+	if seconds < MinGraceSeconds || seconds > MaxGraceSeconds {
+		return ErrInvalidGrace
+	}
+	return nil
+}
+
+// ValidateAlertTopic returns ErrInvalidAlertTopic if the topic is malformed.
+func ValidateAlertTopic(topic string) error {
+	if !alertTopicRegex.MatchString(topic) {
+		return ErrInvalidAlertTopic
+	}
+	return nil
+}
+
+// ValidateAlertPriority returns ErrInvalidAlertPriority if the priority is out of bounds.
+func ValidateAlertPriority(priority int) error {
+	if priority < MinAlertPriority || priority > MaxAlertPriority {
+		return ErrInvalidAlertPriority
+	}
+	return nil
+}

--- a/server/config.go
+++ b/server/config.go
@@ -28,6 +28,7 @@ const (
 	DefaultFirebasePollInterval                 = 20 * time.Minute // ~poll topic (iOS), max. 2-3 times per hour (see docs)
 	DefaultFirebaseQuotaExceededPenaltyDuration = 10 * time.Minute // Time that over-users are locked out of Firebase if it returns "quota exceeded"
 	DefaultStripePriceCacheDuration             = 3 * time.Hour    // Time to keep Stripe prices cached in memory before a refresh is needed
+	DefaultMonitorCheckInterval                 = 30 * time.Second // How often the heartbeat ticker scans for stale monitors
 )
 
 // Platform-specific default paths (set in config_unix.go or config_windows.go)
@@ -191,6 +192,9 @@ type Config struct {
 	WebPushStartupQueries                string
 	WebPushExpiryDuration                time.Duration
 	WebPushExpiryWarningDuration         time.Duration
+	MonitorFile                          string        // Path to monitor SQLite file; empty disables the feature
+	MonitorStartupQueries                string        // PRAGMA-style startup queries for the monitor DB
+	MonitorCheckInterval                 time.Duration // How often the heartbeat ticker runs
 	BuildVersion                         string // Injected by App
 	BuildDate                            string // Injected by App
 	BuildCommit                          string // Injected by App
@@ -290,6 +294,9 @@ func NewConfig() *Config {
 		WebPushEmailAddress:                  "",
 		WebPushExpiryDuration:                DefaultWebPushExpiryDuration,
 		WebPushExpiryWarningDuration:         DefaultWebPushExpiryWarningDuration,
+		MonitorFile:                          "",
+		MonitorStartupQueries:                "",
+		MonitorCheckInterval:                 DefaultMonitorCheckInterval,
 		BuildVersion:                         "",
 		BuildDate:                            "",
 		BuildCommit:                          "",

--- a/server/errors.go
+++ b/server/errors.go
@@ -146,7 +146,15 @@ var (
 	errHTTPBadRequestEmailVerificationCodeInvalid    = &errHTTP{40051, http.StatusBadRequest, "invalid request: email verification code invalid or expired", "", nil}
 	errHTTPBadRequestEmailAddressNotVerified         = &errHTTP{40052, http.StatusBadRequest, "invalid request: email address not verified", "https://ntfy.sh/docs/publish/#e-mail-notifications", nil}
 	errHTTPBadRequestAnonymousEmailNotAllowed        = &errHTTP{40053, http.StatusBadRequest, "invalid request: anonymous email sending is not allowed", "https://ntfy.sh/docs/publish/#e-mail-notifications", nil}
+	errHTTPBadRequestMonitorBodyInvalid              = &errHTTP{40060, http.StatusBadRequest, "invalid request: monitor body must be valid JSON with required fields", "", nil}
+	errHTTPBadRequestMonitorKeyInvalid               = &errHTTP{40061, http.StatusBadRequest, "invalid request: monitor key invalid", "", nil}
+	errHTTPBadRequestMonitorPeriodInvalid            = &errHTTP{40062, http.StatusBadRequest, "invalid request: monitor period out of bounds", "", nil}
+	errHTTPBadRequestMonitorGraceInvalid             = &errHTTP{40063, http.StatusBadRequest, "invalid request: monitor grace out of bounds", "", nil}
+	errHTTPBadRequestMonitorAlertTopicInvalid        = &errHTTP{40064, http.StatusBadRequest, "invalid request: monitor alert topic invalid", "", nil}
+	errHTTPBadRequestMonitorAlertPriorityInvalid     = &errHTTP{40065, http.StatusBadRequest, "invalid request: monitor alert priority out of bounds", "", nil}
+	errHTTPBadRequestMonitorsDisabled                = &errHTTP{40066, http.StatusBadRequest, "invalid request: monitors are not enabled on this server", "", nil}
 	errHTTPNotFound                                  = &errHTTP{40401, http.StatusNotFound, "page not found", "", nil}
+	errHTTPNotFoundMonitor                           = &errHTTP{40402, http.StatusNotFound, "monitor not found", "", nil}
 	errHTTPUnauthorized                              = &errHTTP{40101, http.StatusUnauthorized, "unauthorized", "https://ntfy.sh/docs/publish/#authentication", nil}
 	errHTTPForbidden                                 = &errHTTP{40301, http.StatusForbidden, "forbidden", "https://ntfy.sh/docs/publish/#authentication", nil}
 	errHTTPConflictUserExists                        = &errHTTP{40901, http.StatusConflict, "conflict: user already exists", "", nil}
@@ -156,6 +164,7 @@ var (
 	errHTTPConflictProvisionedUserChange             = &errHTTP{40905, http.StatusConflict, "conflict: cannot change or delete provisioned user", "", nil}
 	errHTTPConflictProvisionedTokenChange            = &errHTTP{40906, http.StatusConflict, "conflict: cannot change or delete provisioned token", "", nil}
 	errHTTPConflictEmailExists                       = &errHTTP{40907, http.StatusConflict, "conflict: email address already exists", "", nil}
+	errHTTPConflictMonitorExists                     = &errHTTP{40908, http.StatusConflict, "conflict: monitor with this key already exists", "", nil}
 	errHTTPGonePhoneVerificationExpired              = &errHTTP{41001, http.StatusGone, "phone number verification expired or does not exist", "", nil}
 	errHTTPEntityTooLargeAttachment                  = &errHTTP{41301, http.StatusRequestEntityTooLarge, "attachment too large, or bandwidth limit reached", "https://ntfy.sh/docs/publish/#limitations", nil}
 	errHTTPEntityTooLargeMatrixRequest               = &errHTTP{41302, http.StatusRequestEntityTooLarge, "Matrix request is larger than the max allowed length", "", nil}

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,7 @@ import (
 	"heckel.io/ntfy/v2/mail"
 	"heckel.io/ntfy/v2/message"
 	"heckel.io/ntfy/v2/model"
+	"heckel.io/ntfy/v2/monitor"
 	"heckel.io/ntfy/v2/payments"
 	"heckel.io/ntfy/v2/user"
 	"heckel.io/ntfy/v2/util"
@@ -65,6 +66,7 @@ type Server struct {
 	messages          int64                               // Total number of messages (persisted if messageCache enabled)
 	messagesHistory   []int64                             // Last n values of the messages counter, used to determine rate
 	userManager       *user.Manager                       // Might be nil!
+	monitorManager    *monitor.Manager                    // Heartbeat monitors; nil when conf.MonitorFile is empty
 	messageCache      *message.Cache                      // Database that stores the messages
 	webPush           *webpush.Store                      // Database that stores web push subscriptions
 	attachment        *attachment.Store                   // Attachment store (file system or S3)
@@ -106,6 +108,9 @@ var (
 	apiTiersPath                                         = "/v1/tiers"
 	apiUsersPath                                         = "/v1/users"
 	apiUsersAccessPath                                   = "/v1/users/access"
+	apiMonitorsPath                                      = "/v1/monitors"
+	apiMonitorsSingleRegex                               = regexp.MustCompile(`^/v1/monitors/([-_A-Za-z0-9]{1,64})$`)
+	apiHeartbeatRegex                                    = regexp.MustCompile(`^/v1/heartbeat/([-_A-Za-z0-9]{1,64})$`)
 	apiAccountPath                                       = "/v1/account"
 	apiAccountTokenPath                                  = "/v1/account/token"
 	apiAccountPasswordPath                               = "/v1/account/password"
@@ -267,6 +272,13 @@ func New(conf *Config) (*Server, error) {
 			return nil, err
 		}
 	}
+	var monitorManager *monitor.Manager
+	if conf.MonitorFile != "" {
+		monitorManager, err = monitor.NewSQLiteManager(conf.MonitorFile, conf.MonitorStartupQueries)
+		if err != nil {
+			return nil, err
+		}
+	}
 	var firebaseClient *firebaseClient
 	if conf.FirebaseKeyFile != "" {
 		sender, err := newFirebaseSender(conf.FirebaseKeyFile)
@@ -292,6 +304,7 @@ func New(conf *Config) (*Server, error) {
 		mailSender:      mailSender,
 		topics:          topics,
 		userManager:     userManager,
+		monitorManager:  monitorManager,
 		messages:        messages,
 		messagesHistory: []int64{messages},
 		visitors:        make(map[string]*visitor),
@@ -421,6 +434,9 @@ func (s *Server) Run() error {
 	go s.runStatsResetter()
 	go s.runDelayedSender()
 	go s.runFirebaseKeepaliver()
+	if s.monitorManager != nil {
+		go s.runMonitorChecker()
+	}
 
 	return <-errChan
 }
@@ -456,6 +472,9 @@ func (s *Server) Stop() {
 func (s *Server) closeDatabases() {
 	if s.userManager != nil {
 		s.userManager.Close()
+	}
+	if s.monitorManager != nil {
+		s.monitorManager.Close()
 	}
 	if s.messageCache != nil {
 		s.messageCache.Close()
@@ -615,6 +634,16 @@ func (s *Server) handleInternal(w http.ResponseWriter, r *http.Request, v *visit
 		return s.ensureUser(s.ensureEmailsEnabled(s.withAccountSync(s.handleAccountEmailAdd)))(w, r, v)
 	} else if r.Method == http.MethodDelete && r.URL.Path == apiAccountEmailPath {
 		return s.ensureUser(s.ensureEmailsEnabled(s.withAccountSync(s.handleAccountEmailDelete)))(w, r, v)
+	} else if r.Method == http.MethodPost && r.URL.Path == apiMonitorsPath {
+		return s.ensureUser(s.ensureMonitorsEnabled(s.handleMonitorAdd))(w, r, v)
+	} else if r.Method == http.MethodGet && r.URL.Path == apiMonitorsPath {
+		return s.ensureUser(s.ensureMonitorsEnabled(s.handleMonitorList))(w, r, v)
+	} else if r.Method == http.MethodGet && apiMonitorsSingleRegex.MatchString(r.URL.Path) {
+		return s.ensureUser(s.ensureMonitorsEnabled(s.handleMonitorGet))(w, r, v)
+	} else if r.Method == http.MethodDelete && apiMonitorsSingleRegex.MatchString(r.URL.Path) {
+		return s.ensureUser(s.ensureMonitorsEnabled(s.handleMonitorDelete))(w, r, v)
+	} else if (r.Method == http.MethodGet || r.Method == http.MethodPost) && apiHeartbeatRegex.MatchString(r.URL.Path) {
+		return s.ensureUser(s.ensureMonitorsEnabled(s.handleHeartbeat))(w, r, v)
 	} else if r.Method == http.MethodPost && apiWebPushPath == r.URL.Path {
 		return s.ensureWebPushEnabled(s.limitRequests(s.handleWebPushUpdate))(w, r, v)
 	} else if r.Method == http.MethodDelete && apiWebPushPath == r.URL.Path {

--- a/server/server_monitor.go
+++ b/server/server_monitor.go
@@ -1,0 +1,277 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"strings"
+	"time"
+
+	"heckel.io/ntfy/v2/log"
+	"heckel.io/ntfy/v2/model"
+	"heckel.io/ntfy/v2/monitor"
+	"heckel.io/ntfy/v2/user"
+)
+
+const tagMonitor = "monitor"
+
+// Request and response payloads.
+
+type monitorAddRequest struct {
+	Key           string `json:"key"`
+	Period        int64  `json:"period"`
+	Grace         int64  `json:"grace"`
+	AlertTopic    string `json:"alert_topic"`
+	AlertPriority *int   `json:"alert_priority,omitempty"` // pointer so 0 is distinguishable from unset
+}
+
+type monitorResponse struct {
+	Key           string `json:"key"`
+	Period        int64  `json:"period"`
+	Grace         int64  `json:"grace"`
+	AlertTopic    string `json:"alert_topic"`
+	AlertPriority int    `json:"alert_priority"`
+	State         string `json:"state"`
+	LastSeenAt    int64  `json:"last_seen_at"`
+	CreatedAt     int64  `json:"created_at"`
+}
+
+type monitorListResponse struct {
+	Monitors []*monitorResponse `json:"monitors"`
+}
+
+type heartbeatResponse struct {
+	Key        string `json:"key"`
+	State      string `json:"state"`
+	PrevState  string `json:"prev_state"`
+	LastSeenAt int64  `json:"last_seen_at"`
+}
+
+type monitorDeleteResponse struct {
+	OK bool `json:"ok"`
+}
+
+func monitorToResponse(m *monitor.Monitor) *monitorResponse {
+	return &monitorResponse{
+		Key:           m.Key,
+		Period:        m.PeriodSeconds,
+		Grace:         m.GraceSeconds,
+		AlertTopic:    m.AlertTopic,
+		AlertPriority: m.AlertPriority,
+		State:         m.State,
+		LastSeenAt:    m.LastSeenAt,
+		CreatedAt:     m.CreatedAt,
+	}
+}
+
+// ensureMonitorsEnabled is a middleware that returns an error if the monitor feature is disabled.
+func (s *Server) ensureMonitorsEnabled(next handleFunc) handleFunc {
+	return func(w http.ResponseWriter, r *http.Request, v *visitor) error {
+		if s.monitorManager == nil {
+			return errHTTPBadRequestMonitorsDisabled
+		}
+		return next(w, r, v)
+	}
+}
+
+// keyFromPath extracts the trailing path segment (the monitor key) from a URL like
+// /v1/monitors/<key> or /v1/heartbeat/<key>.
+func keyFromPath(path string) string {
+	i := strings.LastIndex(path, "/")
+	if i < 0 || i == len(path)-1 {
+		return ""
+	}
+	return path[i+1:]
+}
+
+func (s *Server) handleMonitorAdd(w http.ResponseWriter, r *http.Request, v *visitor) error {
+	u := v.User()
+	req, err := readJSONWithLimit[monitorAddRequest](r.Body, jsonBodyBytesLimit, false)
+	if err != nil {
+		return errHTTPBadRequestMonitorBodyInvalid
+	}
+	priority := monitor.DefaultAlertPriority
+	if req.AlertPriority != nil {
+		priority = *req.AlertPriority
+	}
+	mon, err := s.monitorManager.AddMonitor(u.ID, req.Key, req.Period, req.Grace, req.AlertTopic, priority)
+	if err != nil {
+		return mapMonitorError(err)
+	}
+	return s.writeJSON(w, monitorToResponse(mon))
+}
+
+func (s *Server) handleMonitorList(w http.ResponseWriter, r *http.Request, v *visitor) error {
+	u := v.User()
+	mons, err := s.monitorManager.ListMonitorsByUser(u.ID)
+	if err != nil {
+		return err
+	}
+	out := make([]*monitorResponse, 0, len(mons))
+	for _, m := range mons {
+		out = append(out, monitorToResponse(m))
+	}
+	return s.writeJSON(w, &monitorListResponse{Monitors: out})
+}
+
+func (s *Server) handleMonitorGet(w http.ResponseWriter, r *http.Request, v *visitor) error {
+	u := v.User()
+	key := keyFromPath(r.URL.Path)
+	if err := monitor.ValidateKey(key); err != nil {
+		return errHTTPBadRequestMonitorKeyInvalid
+	}
+	mon, err := s.monitorManager.GetMonitor(u.ID, key)
+	if err != nil {
+		return mapMonitorError(err)
+	}
+	return s.writeJSON(w, monitorToResponse(mon))
+}
+
+func (s *Server) handleMonitorDelete(w http.ResponseWriter, r *http.Request, v *visitor) error {
+	u := v.User()
+	key := keyFromPath(r.URL.Path)
+	if err := monitor.ValidateKey(key); err != nil {
+		return errHTTPBadRequestMonitorKeyInvalid
+	}
+	if err := s.monitorManager.DeleteMonitor(u.ID, key); err != nil {
+		return mapMonitorError(err)
+	}
+	return s.writeJSON(w, &monitorDeleteResponse{OK: true})
+}
+
+func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request, v *visitor) error {
+	u := v.User()
+	key := keyFromPath(r.URL.Path)
+	if err := monitor.ValidateKey(key); err != nil {
+		return errHTTPBadRequestMonitorKeyInvalid
+	}
+	mon, prev, err := s.monitorManager.RecordHeartbeat(u.ID, key)
+	if err != nil {
+		return mapMonitorError(err)
+	}
+	if prev == monitor.StateDown {
+		go s.publishMonitorAlert(mon, true)
+	}
+	return s.writeJSON(w, &heartbeatResponse{
+		Key:        mon.Key,
+		State:      mon.State,
+		PrevState:  prev,
+		LastSeenAt: mon.LastSeenAt,
+	})
+}
+
+// publishMonitorAlert publishes a DOWN or UP recovery message to mon.AlertTopic, attributed to
+// the monitor owner. Mirrors the sendDelayedMessage path: forward to active subscribers, cache
+// for offline subscribers, and (if configured) deliver via Firebase and Web Push.
+func (s *Server) publishMonitorAlert(mon *monitor.Monitor, recovery bool) {
+	owner, err := s.lookupMonitorOwner(mon)
+	if err != nil {
+		log.Tag(tagMonitor).Err(err).Warn("Monitor %s: unable to look up owner %s; alert dropped", mon.Key, mon.UserID)
+		return
+	}
+	t, err := s.topicFromID(mon.AlertTopic)
+	if err != nil {
+		log.Tag(tagMonitor).Err(err).Warn("Monitor %s: unable to resolve alert topic %s; alert dropped", mon.Key, mon.AlertTopic)
+		return
+	}
+	v := s.visitor(netip.IPv4Unspecified(), owner)
+
+	m := model.NewDefaultMessage(mon.AlertTopic, monitorMessageBody(mon, recovery))
+	m.Title = monitorMessageTitle(mon, recovery)
+	m.Priority = mon.AlertPriority
+	if recovery {
+		m.Tags = []string{"white_check_mark"}
+	} else {
+		m.Tags = []string{"warning"}
+	}
+	m.Expires = time.Now().Add(s.config.CacheDuration).Unix()
+	if owner != nil {
+		m.User = owner.ID
+	}
+	m.SanitizeUTF8()
+
+	if err := t.Publish(v, m); err != nil {
+		log.Tag(tagMonitor).Err(err).Warn("Monitor %s: unable to publish alert", mon.Key)
+	}
+	if err := s.messageCache.AddMessage(m); err != nil {
+		log.Tag(tagMonitor).Err(err).Warn("Monitor %s: unable to cache alert message", mon.Key)
+	}
+	if s.firebaseClient != nil {
+		go s.sendToFirebase(v, m)
+	}
+	if s.config.WebPushPublicKey != "" {
+		go s.publishToWebPushEndpoints(v, m)
+	}
+}
+
+func (s *Server) lookupMonitorOwner(mon *monitor.Monitor) (*user.User, error) {
+	if s.userManager == nil || mon.UserID == "" {
+		return nil, errors.New("user manager not configured or monitor has no owner")
+	}
+	return s.userManager.UserByID(mon.UserID)
+}
+
+func monitorMessageTitle(mon *monitor.Monitor, recovery bool) string {
+	if recovery {
+		return fmt.Sprintf("Monitor %s is UP", mon.Key)
+	}
+	return fmt.Sprintf("Monitor %s is DOWN", mon.Key)
+}
+
+func monitorMessageBody(mon *monitor.Monitor, recovery bool) string {
+	if recovery {
+		return fmt.Sprintf("Heartbeat received; monitor %s recovered after being down.", mon.Key)
+	}
+	return fmt.Sprintf("No heartbeat for at least %ds (period=%ds, grace=%ds).", mon.PeriodSeconds+mon.GraceSeconds, mon.PeriodSeconds, mon.GraceSeconds)
+}
+
+// runMonitorChecker periodically scans for stale Up monitors, transitions them to Down, and
+// publishes DOWN alerts. Up->Down transitions originate here; Down->Up happens in handleHeartbeat.
+func (s *Server) runMonitorChecker() {
+	for {
+		select {
+		case <-time.After(s.config.MonitorCheckInterval):
+			if err := s.checkMonitors(); err != nil {
+				log.Tag(tagMonitor).Err(err).Warn("Monitor check failed")
+			}
+		case <-s.closeChan:
+			return
+		}
+	}
+}
+
+func (s *Server) checkMonitors() error {
+	stale, err := s.monitorManager.StaleMonitors()
+	if err != nil {
+		return err
+	}
+	for _, mon := range stale {
+		if err := s.monitorManager.MarkDown(mon.ID); err != nil {
+			log.Tag(tagMonitor).Err(err).Warn("Monitor %s: failed to mark down", mon.Key)
+			continue
+		}
+		s.publishMonitorAlert(mon, false)
+	}
+	return nil
+}
+
+func mapMonitorError(err error) error {
+	switch {
+	case errors.Is(err, monitor.ErrMonitorNotFound):
+		return errHTTPNotFoundMonitor
+	case errors.Is(err, monitor.ErrMonitorExists):
+		return errHTTPConflictMonitorExists
+	case errors.Is(err, monitor.ErrInvalidKey):
+		return errHTTPBadRequestMonitorKeyInvalid
+	case errors.Is(err, monitor.ErrInvalidPeriod):
+		return errHTTPBadRequestMonitorPeriodInvalid
+	case errors.Is(err, monitor.ErrInvalidGrace):
+		return errHTTPBadRequestMonitorGraceInvalid
+	case errors.Is(err, monitor.ErrInvalidAlertTopic):
+		return errHTTPBadRequestMonitorAlertTopicInvalid
+	case errors.Is(err, monitor.ErrInvalidAlertPriority):
+		return errHTTPBadRequestMonitorAlertPriorityInvalid
+	}
+	return err
+}

--- a/server/server_monitor_test.go
+++ b/server/server_monitor_test.go
@@ -1,0 +1,256 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"heckel.io/ntfy/v2/model"
+	"heckel.io/ntfy/v2/monitor"
+	"heckel.io/ntfy/v2/user"
+	"heckel.io/ntfy/v2/util"
+)
+
+func newTestConfigWithMonitor(t *testing.T) *Config {
+	conf := newTestConfigWithAuthFile(t, "")
+	conf.MonitorFile = filepath.Join(t.TempDir(), "monitor.db")
+	conf.MonitorCheckInterval = time.Hour // disable the background ticker for handler tests
+	return conf
+}
+
+func addUser(t *testing.T, s *Server, name string) {
+	require.Nil(t, s.userManager.AddUser(name, name, user.RoleUser, false))
+}
+
+func basicAuth(name string) map[string]string {
+	return map[string]string{"Authorization": util.BasicAuth(name, name)}
+}
+
+func TestMonitor_Add_Success(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+
+	body := `{"key":"scanner","period":300,"grace":60,"alert_topic":"alerts","alert_priority":4}`
+	rr := request(t, s, "POST", "/v1/monitors", body, basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+
+	var resp monitorResponse
+	require.Nil(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(t, "scanner", resp.Key)
+	require.Equal(t, int64(300), resp.Period)
+	require.Equal(t, int64(60), resp.Grace)
+	require.Equal(t, "alerts", resp.AlertTopic)
+	require.Equal(t, 4, resp.AlertPriority)
+	require.Equal(t, monitor.StatePending, resp.State)
+}
+
+func TestMonitor_Add_DefaultPriority(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+
+	body := `{"key":"scanner","period":300,"grace":60,"alert_topic":"alerts"}`
+	rr := request(t, s, "POST", "/v1/monitors", body, basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+	resp, _ := util.UnmarshalJSON[monitorResponse](io.NopCloser(rr.Body))
+	require.Equal(t, monitor.DefaultAlertPriority, resp.AlertPriority)
+}
+
+func TestMonitor_Add_Unauthorized(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	rr := request(t, s, "POST", "/v1/monitors", `{"key":"x","period":300,"grace":60,"alert_topic":"a"}`, nil)
+	require.Equal(t, 401, rr.Code)
+}
+
+func TestMonitor_Add_DuplicateKey(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+
+	body := `{"key":"scanner","period":300,"grace":60,"alert_topic":"alerts"}`
+	rr := request(t, s, "POST", "/v1/monitors", body, basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+	rr = request(t, s, "POST", "/v1/monitors", body, basicAuth("phil"))
+	require.Equal(t, 409, rr.Code)
+	require.Equal(t, 40908, toHTTPError(t, rr.Body.String()).Code)
+}
+
+func TestMonitor_Add_FeatureDisabled(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithAuthFile(t, ""))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+	rr := request(t, s, "POST", "/v1/monitors", `{"key":"x","period":300,"grace":60,"alert_topic":"a"}`, basicAuth("phil"))
+	require.Equal(t, 400, rr.Code)
+	require.Equal(t, 40066, toHTTPError(t, rr.Body.String()).Code)
+}
+
+func TestMonitor_Add_BadBody(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+	rr := request(t, s, "POST", "/v1/monitors", `not json`, basicAuth("phil"))
+	require.Equal(t, 400, rr.Code)
+	require.Equal(t, 40060, toHTTPError(t, rr.Body.String()).Code)
+}
+
+func TestMonitor_Add_ValidationErrors(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+
+	cases := []struct {
+		name string
+		body string
+		code int
+	}{
+		{"bad key", `{"key":"bad/key","period":300,"grace":60,"alert_topic":"a"}`, 40061},
+		{"period low", `{"key":"k","period":1,"grace":60,"alert_topic":"a"}`, 40062},
+		{"grace low", `{"key":"k","period":300,"grace":0,"alert_topic":"a"}`, 40063},
+		{"bad topic", `{"key":"k","period":300,"grace":60,"alert_topic":"bad/topic"}`, 40064},
+		{"prio high", `{"key":"k","period":300,"grace":60,"alert_topic":"a","alert_priority":9}`, 40065},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := request(t, s, "POST", "/v1/monitors", tc.body, basicAuth("phil"))
+			require.Equal(t, 400, rr.Code)
+			require.Equal(t, tc.code, toHTTPError(t, rr.Body.String()).Code)
+		})
+	}
+}
+
+func TestMonitor_List_ScopedToUser(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+	addUser(t, s, "ben")
+
+	for i := 0; i < 3; i++ {
+		body := fmt.Sprintf(`{"key":"k%d","period":300,"grace":60,"alert_topic":"a"}`, i)
+		rr := request(t, s, "POST", "/v1/monitors", body, basicAuth("phil"))
+		require.Equal(t, 200, rr.Code)
+	}
+	rr := request(t, s, "POST", "/v1/monitors", `{"key":"ben1","period":300,"grace":60,"alert_topic":"a"}`, basicAuth("ben"))
+	require.Equal(t, 200, rr.Code)
+
+	rr = request(t, s, "GET", "/v1/monitors", "", basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+	list, _ := util.UnmarshalJSON[monitorListResponse](io.NopCloser(rr.Body))
+	require.Len(t, list.Monitors, 3)
+
+	rr = request(t, s, "GET", "/v1/monitors", "", basicAuth("ben"))
+	require.Equal(t, 200, rr.Code)
+	list, _ = util.UnmarshalJSON[monitorListResponse](io.NopCloser(rr.Body))
+	require.Len(t, list.Monitors, 1)
+	require.Equal(t, "ben1", list.Monitors[0].Key)
+}
+
+func TestMonitor_Get_NotFound(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+	rr := request(t, s, "GET", "/v1/monitors/ghost", "", basicAuth("phil"))
+	require.Equal(t, 404, rr.Code)
+	require.Equal(t, 40402, toHTTPError(t, rr.Body.String()).Code)
+}
+
+func TestMonitor_Delete(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+	rr := request(t, s, "POST", "/v1/monitors", `{"key":"x","period":300,"grace":60,"alert_topic":"a"}`, basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+	rr = request(t, s, "DELETE", "/v1/monitors/x", "", basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+	rr = request(t, s, "DELETE", "/v1/monitors/x", "", basicAuth("phil"))
+	require.Equal(t, 404, rr.Code)
+}
+
+func TestMonitor_Heartbeat_PendingToUp(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+	rr := request(t, s, "POST", "/v1/monitors", `{"key":"scanner","period":300,"grace":60,"alert_topic":"alerts"}`, basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+
+	rr = request(t, s, "POST", "/v1/heartbeat/scanner", "", basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+	resp, _ := util.UnmarshalJSON[heartbeatResponse](io.NopCloser(rr.Body))
+	require.Equal(t, monitor.StateUp, resp.State)
+	require.Equal(t, monitor.StatePending, resp.PrevState)
+}
+
+func TestMonitor_Heartbeat_DownToUp_PublishesAlert(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+	rr := request(t, s, "POST", "/v1/monitors", `{"key":"scanner","period":300,"grace":60,"alert_topic":"alerts"}`, basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+
+	// Directly mark down via the manager to simulate a missed heartbeat
+	mon, err := s.monitorManager.GetMonitor(currentUserID(t, s, "phil"), "scanner")
+	require.Nil(t, err)
+	require.Nil(t, s.monitorManager.MarkDown(mon.ID))
+
+	rr = request(t, s, "POST", "/v1/heartbeat/scanner", "", basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+	resp, _ := util.UnmarshalJSON[heartbeatResponse](io.NopCloser(rr.Body))
+	require.Equal(t, monitor.StateUp, resp.State)
+	require.Equal(t, monitor.StateDown, resp.PrevState)
+
+	// publishMonitorAlert runs in a goroutine; give it a moment
+	waitFor(t, func() bool {
+		msgs, err := s.messageCache.Messages("alerts", model.SinceAllMessages, false)
+		require.Nil(t, err)
+		for _, m := range msgs {
+			if m.Title == "Monitor scanner is UP" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestMonitor_CheckMonitors_UpToDown_PublishesAlert(t *testing.T) {
+	s := newTestServer(t, newTestConfigWithMonitor(t))
+	defer s.closeDatabases()
+	addUser(t, s, "phil")
+	rr := request(t, s, "POST", "/v1/monitors", `{"key":"scanner","period":30,"grace":10,"alert_topic":"alerts"}`, basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+	rr = request(t, s, "POST", "/v1/heartbeat/scanner", "", basicAuth("phil"))
+	require.Equal(t, 200, rr.Code)
+
+	// Backdate last_seen_at so the monitor is stale on the next check
+	userID := currentUserID(t, s, "phil")
+	mon, err := s.monitorManager.GetMonitor(userID, "scanner")
+	require.Nil(t, err)
+	require.Nil(t, s.monitorManager.SetLastSeenAt(mon.ID, time.Now().Unix()-1000))
+
+	require.Nil(t, s.checkMonitors())
+
+	got, err := s.monitorManager.GetMonitor(userID, "scanner")
+	require.Nil(t, err)
+	require.Equal(t, monitor.StateDown, got.State)
+
+	waitFor(t, func() bool {
+		msgs, err := s.messageCache.Messages("alerts", model.SinceAllMessages, false)
+		require.Nil(t, err)
+		for _, m := range msgs {
+			if m.Title == "Monitor scanner is DOWN" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func currentUserID(t *testing.T, s *Server, name string) string {
+	u, err := s.userManager.User(name)
+	require.Nil(t, err)
+	return u.ID
+}


### PR DESCRIPTION
## Summary

Adds an opt-in heartbeat / dead-man's-switch subsystem to the ntfy server. Authenticated users register a monitor with a key, period, grace, and alert topic; the script/service being watched POSTs to `/v1/heartbeat/<key>` on a schedule, and a missed window causes ntfy to publish a DOWN alert on the configured topic (recovery UP alert when pings resume).

This is opt-in: with no `MonitorFile` configured, the routes return `40066 monitors not enabled` and the background goroutine does not start, so behavior is identical to current ntfy for users who don't enable it.

I built and deployed this on my own server and have been pinging from a real cron'd script for a few hours — DOWN and UP alerts both fire reliably end-to-end (Android notification, message in topic, web push, all work).

## Context / prior art

I'm aware of:
- #1498 (open feature request) — but that one is specifically about *mobile-app-side* absence detection, which this PR does not address. The use cases overlap, but the implementation surface is completely different.
- #1425 (merged) — added docs pointing to the external `ntfy-heartbeat-monitor` tool, which polls topics from outside ntfy.

I'm submitting this in case a built-in option is interesting; happy to close if the project's direction is firmly "use external tools." The motivation for me was simplicity (one fewer moving part for self-hosters who already have ntfy) and that the external tool model requires another service that itself needs monitoring.

## API

All endpoints require authentication and are scoped per user:

| Method  | Path                       | Purpose                  |
|---------|----------------------------|--------------------------|
| `POST`  | `/v1/monitors`             | Create monitor           |
| `GET`   | `/v1/monitors`             | List user's monitors     |
| `GET`   | `/v1/monitors/<key>`       | Get one                  |
| `DELETE`| `/v1/monitors/<key>`       | Delete                   |
| `GET`/`POST` | `/v1/heartbeat/<key>` | Record heartbeat         |

Create body: `{key, period, grace, alert_topic, alert_priority?}`

## How alerts are delivered

`publishMonitorAlert` mirrors `sendDelayedMessage` — it looks up the topic, attributes the message to the monitor owner (via the existing `userManager`), and goes through the normal publish path: forward to active subscribers, cache for offline subscribers, Firebase, Web Push.

## State machine

- New monitor: `pending` (no alerts yet — first ping required)
- Heartbeat arrives: `pending|down → up`. On `down → up`, recovery alert published.
- Background ticker every `MonitorCheckInterval` (default 30s): any `up` monitor with `now > last_seen + period + grace` flips to `down` and an alert is published.

## Configuration

New CLI flags / env vars:
- `--monitor-file` / `NTFY_MONITOR_FILE` (empty = feature off)
- `--monitor-startup-queries` / `NTFY_MONITOR_STARTUP_QUERIES`
- `--monitor-check-interval` / `NTFY_MONITOR_CHECK_INTERVAL` (default 30s)

## What's intentionally NOT in this PR

These are deliberate to keep the diff focused; happy to extend if there's interest:

- **No PostgreSQL backend.** The `monitor` package is SQLite-only. Other packages support both via the queries-struct pattern; this could be added later but I wanted to keep the initial diff small.
- **No web UI.** The feature is API-only for now. The web app would benefit from a /monitors page; out of scope here.
- **No user docs.** Will add `docs/config.md` + `docs/publish.md` content if the feature direction is acceptable.
- **No Android-app changes.** This PR is server-side only. The mobile concern in #1498 is separate.

## Test plan

- [x] 27 unit + integration tests added (monitor package + server handlers)
- [x] Full `go test ./monitor/... ./server/...` passes
- [x] Build and `go vet ./...` clean
- [x] Deployed and exercised against a real cron'd script — DOWN and UP alerts both verified end-to-end on Android via ntfy app + Firebase + Web Push
- [x] Verified that with `MonitorFile=""` (default) all endpoints return 40066 and no goroutine starts, so behavior is unchanged for existing deployments