### PR TITLE
Add directories for attachment, mail, and s3 to Dockerfile-build

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -45,6 +45,9 @@ ADD ./db ./db
 ADD ./message ./message
 ADD ./model ./model
 ADD ./webpush ./webpush
+ADD ./attachment ./attachment
+ADD ./mail ./mail
+ADD ./s3 ./s3
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server
 
 FROM alpine


### PR DESCRIPTION
Added new directories for attachment, mail, and s3 to the docker build process.

build was failing with 

>16.61     │ server/server.go:39:2: no required module provides package heckel.io/ntfy/v2/mail; to add it:

# testing
```
./make docker-dev
......
 => [builder 29/29] RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-buil  329.5s
 => [stage-1 2/2] COPY --from=builder /app/dist/ntfy_linux_server/ntfy /usr/bin/ntfy                            0.6s
 => exporting to image                                                                                          0.2s
 => => exporting layers                                                                                         0.2s
 => => writing image sha256:bbfdfaeb07240af8fabd42953911d80595cb2cdf3033df3fe329d6281961d900                    0.0s
 => => naming to docker.io/binwiederhier/ntfy:v2.22.0                                                           0.0s
 => => naming to docker.io/binwiederhier/ntfy:dev  
```