### PR TITLE
docs: add ntfy Desktop (Windows) to CLIs + GUIs

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -89,6 +89,7 @@ I've added a ⭐ to projects or posts that have a significant following, or had 
 - [ntfy-desktop](https://codeberg.org/zvava/ntfy-desktop) - Cross-platform desktop application for ntfy
 - [ntfy-desktop](https://github.com/Aetherinox/ntfy-desktop) - Desktop client for Windows, Linux, and MacOS with push notifications
 - [ntfy svelte front-end](https://github.com/novatorem/Ntfy) - Front-end built with svelte
+- [ntfy Desktop (Windows)](https://github.com/simoneferrari/ntfy-desktop) - Native Windows desktop client with multi-server support, toast notifications and message history, built with WPF and .NET (C#)
 - [wio-ntfy-ticker](https://github.com/nachotp/wio-ntfy-ticker) - Ticker display for a ntfy.sh topic
 - [ntfysh-windows](https://github.com/mshafer1/ntfysh-windows) - A ntfy client for Windows Desktop
 - [ntfyr](https://github.com/haxwithaxe/ntfyr) - A simple commandline tool to send notifications to ntfy


### PR DESCRIPTION
Adds my open-source Windows desktop client to the CLIs + GUIs list.

- Repo: https://github.com/simoneferrari/ntfy-desktop
- Native Windows app (WPF / .NET), MIT-licensed
- Supports multiple ntfy servers, per-topic settings, toast notifications, an in-app feed with history, and active hours

Named "ntfy Desktop (Windows)" in the entry to distinguish it from the existing cross-platform/Linux entries with similar names.