### PR TITLE
Play notification sounds from the page ignoring Notification API support

### DIFF
--- a/web/src/app/Notifier.js
+++ b/web/src/app/Notifier.js
@@ -11,11 +11,11 @@ class Notifier {
   lastSoundPlayedAt = 0;
 
   async notify(subscription, notification) {
+    await this.playSound();
+    
     if (!this.supported()) {
       return;
     }
-
-    await this.playSound();
 
     const shortUrl = topicShortUrl(subscription.baseUrl, subscription.topic);
     const defaultTitle = topicDisplayName(subscription);


### PR DESCRIPTION
HTMLAudioElement is not constrained by Notification API being inaccessible. Skipping the check allows for audio-only notifications in browsers not supporting Notification API and HTTP environments.