### PR TITLE
Feature/legal and contact info

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -104,6 +104,11 @@ var flagsServe = append(
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "stripe-secret-key", Aliases: []string{"stripe_secret_key"}, EnvVars: []string{"NTFY_STRIPE_SECRET_KEY"}, Value: "", Usage: "key used for the Stripe API communication, this enables payments"}),
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "stripe-webhook-key", Aliases: []string{"stripe_webhook_key"}, EnvVars: []string{"NTFY_STRIPE_WEBHOOK_KEY"}, Value: "", Usage: "key required to validate the authenticity of incoming webhooks from Stripe"}),
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "billing-contact", Aliases: []string{"billing_contact"}, EnvVars: []string{"NTFY_BILLING_CONTACT"}, Value: "", Usage: "e-mail or website to display in upgrade dialog (only if payments are enabled)"}),
+	//Name
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "legal-name", Aliases: []string{"legal_name"}, EnvVars: []string{"NTFY_LEGAL_NAME"}, Value: "", Usage: "stores the server maintainer's full legal name"}),
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "legal-email", Aliases: []string{"legal_email"}, EnvVars: []string{"NTFY_LEGAL_EMAIL"}, Value: "", Usage: "stores the contact email address for legal inquiries"}),
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "privacy-policy-url", Aliases: []string{"privacy_policy_url"}, EnvVars: []string{"NTFY_PRIVACY_POLICY_URL"}, Value: "", Usage: "URL link to the server's privacy policy page"}),
+	altsrc.NewStringFlag(&cli.StringFlag{Name: "legal-notice-url", Aliases: []string{"legal_notice_url"}, EnvVars: []string{"NTFY_LEGAL_NOTICE_URL"}, Value: "", Usage: "URL link to the server's legal notice or impressum page"}),
 	altsrc.NewBoolFlag(&cli.BoolFlag{Name: "enable-metrics", Aliases: []string{"enable_metrics"}, EnvVars: []string{"NTFY_ENABLE_METRICS"}, Value: false, Usage: "if set, Prometheus metrics are exposed via the /metrics endpoint"}),
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "metrics-listen-http", Aliases: []string{"metrics_listen_http"}, EnvVars: []string{"NTFY_METRICS_LISTEN_HTTP"}, Usage: "ip:port used to expose the metrics endpoint (implicitly enables metrics)"}),
 	altsrc.NewStringFlag(&cli.StringFlag{Name: "profile-listen-http", Aliases: []string{"profile_listen_http"}, EnvVars: []string{"NTFY_PROFILE_LISTEN_HTTP"}, Usage: "ip:port used to expose the profiling endpoints (implicitly enables profiling)"}),
@@ -224,6 +229,11 @@ func execServe(c *cli.Context) error {
 	metricsListenHTTP := c.String("metrics-listen-http")
 	enableMetrics := c.Bool("enable-metrics") || metricsListenHTTP != ""
 	profileListenHTTP := c.String("profile-listen-http")
+	legalName := c.String("legal-name")
+	legalEmail := c.String("legal-email")
+	privacyPolicy := c.String("privacy-policy-url")
+	legalNotice := c.String("legal-notice-url")
+
 
 	// Convert durations
 	cacheDuration, err := util.ParseDuration(cacheDurationStr)
@@ -537,6 +547,11 @@ func execServe(c *cli.Context) error {
 	conf.BuildVersion = c.App.Version
 	conf.BuildDate = maybeFromMetadata(c.App.Metadata, MetadataKeyDate)
 	conf.BuildCommit = maybeFromMetadata(c.App.Metadata, MetadataKeyCommit)
+	conf.LegalName = legalName
+	conf.LegalEmail = legalEmail
+	conf.PrivacyPolicyURL = privacyPolicy
+	conf.LegalNoticeURL = legalNotice
+
 
 	// Check if we should run as a Windows service
 	if ranAsService, err := maybeRunAsService(conf); err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -200,6 +200,13 @@ type Config struct {
 	BuildVersion                         string // Injected by App
 	BuildDate                            string // Injected by App
 	BuildCommit                          string // Injected by App
+    LegalName                            string `yaml:"legal-name" json:"legal_name"`
+    LegalEmail                           string `yaml:"legal-email" json:"legal_email"`
+    PrivacyPolicyURL                     string `yaml:"privacy-policy-url" json:"privacy_policy_url"`
+    LegalNoticeURL                       string `yaml:"legal-notice-url" json:"legal_notice_url"`
+
+
+
 }
 
 // NewConfig instantiates a default new server config
@@ -303,6 +310,10 @@ func NewConfig() *Config {
 		BuildVersion:                         "",
 		BuildDate:                            "",
 		BuildCommit:                          "",
+		LegalName:                            "",
+		LegalEmail:                           "",
+		PrivacyPolicyURL:                     "",
+		LegalNoticeURL:                       "",
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -730,6 +730,10 @@ func (s *Server) configResponse() *apiConfigResponse {
 		WebPushPublicKey:   s.config.WebPushPublicKey,
 		DisallowedTopics:   s.config.DisallowedTopics,
 		ConfigHash:         s.config.Hash(),
+		LegalName:        	s.config.LegalName,
+		LegalEmail:       	s.config.LegalEmail,
+		PrivacyPolicyURL: s.config.PrivacyPolicyURL,
+    	LegalNoticeURL:   s.config.LegalNoticeURL,  
 	}
 }
 

--- a/server/types.go
+++ b/server/types.go
@@ -319,6 +319,10 @@ type apiConfigResponse struct {
 	WebPushPublicKey   string   `json:"web_push_public_key"`
 	DisallowedTopics   []string `json:"disallowed_topics"`
 	ConfigHash         string   `json:"config_hash"`
+	LegalName          string   `json:"legal_name"`
+	LegalEmail         string   `json:"legal_email"`
+	PrivacyPolicyURL string `json:"privacy_policy_url"`
+    LegalNoticeURL   string `json:"legal_notice_url"`
 }
 
 type apiAccountBillingPrices struct {

--- a/web/public/static/langs/ar.json
+++ b/web/public/static/langs/ar.json
@@ -364,5 +364,10 @@
     "prefs_appearance_theme_system": "النظام (الافتراضي)",
     "prefs_notifications_min_priority_low_and_higher": "أولوية منخفضة وأعلى",
     "prefs_notifications_min_priority_default_and_higher": "الأولوية الافتراضية وما فوقها",
-    "prefs_notifications_min_priority_high_and_higher": "أولوية عالية وأعلى"
+    "prefs_notifications_min_priority_high_and_higher": "أولوية عالية وأعلى",
+    "prefs_legal_contact_title": "معلومات الاتصال:",
+    "prefs_legal_name": "الاسم",
+    "prefs_legal_email": "البريد الإلكتروني",
+    "prefs_legal_notice": "إشعار قانوني",
+    "prefs_privacy_policy": "سياسة الخصوصية"
 }

--- a/web/public/static/langs/bg.json
+++ b/web/public/static/langs/bg.json
@@ -405,5 +405,10 @@
     "web_push_subscription_expiring_body": "За да продължите да получавате известия, отворете ntfy",
     "action_bar_unmute_notifications": "Включване звука на известията",
     "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Кодът за защита от външна система не може да бъде променян или премахван",
-    "account_basics_cannot_edit_or_delete_provisioned_user": "Потребител от външна система не може да бъде променян или премахван"
+    "account_basics_cannot_edit_or_delete_provisioned_user": "Потребител от външна система не може да бъде променян или премахван",
+    "prefs_legal_contact_title": "Контакти:",
+    "prefs_legal_name": "Име",
+    "prefs_legal_email": "Имейл",
+    "prefs_legal_notice": "Правна информация",
+    "prefs_privacy_policy": "Политика за поверителност"
 }

--- a/web/public/static/langs/ca.json
+++ b/web/public/static/langs/ca.json
@@ -40,5 +40,10 @@
     "action_bar_profile_logout": "Tancar sessió",
     "action_bar_sign_in": "Iniciar sessió",
     "action_bar_sign_up": "Crear compte",
-    "message_bar_type_message": "Escriu un missatge aquí"
+    "message_bar_type_message": "Escriu un missatge aquí",
+    "prefs_legal_contact_title": "Contacte:",
+    "prefs_legal_name": "Nom",
+    "prefs_legal_email": "Correu electrònic",
+    "prefs_legal_notice": "Avís legal",
+    "prefs_privacy_policy": "Política de privadesa"
 }

--- a/web/public/static/langs/cs.json
+++ b/web/public/static/langs/cs.json
@@ -405,5 +405,10 @@
     "web_push_unknown_notification_title": "Neznámé oznámení přijaté ze serveru",
     "web_push_unknown_notification_body": "Možná bude nutné aktualizovat ntfy otevřením webové aplikace",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Přiděleného uživatele nelze upravovat ani odstranit",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Nelze upravit ani odstranit přidělený token"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Nelze upravit ani odstranit přidělený token",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Jméno",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Právní upozornění",
+    "prefs_privacy_policy": "Zásady ochrany osobních údajů"
 }

--- a/web/public/static/langs/cu.json
+++ b/web/public/static/langs/cu.json
@@ -4,5 +4,10 @@
     "common_add": "Приложити",
     "common_back": "Назадъ",
     "login_form_button_submit": "Въниди",
-    "signup_form_password": "Таино слово"
+    "signup_form_password": "Таино слово",
+    "prefs_legal_contact_title": "Контактъ:",
+    "prefs_legal_name": "Имя:",
+    "prefs_legal_email": "Электронная почта:",
+    "prefs_legal_notice": "Юридическое уведомление",
+    "prefs_privacy_policy": "Политика конфиденциальности"
 }

--- a/web/public/static/langs/cy.json
+++ b/web/public/static/langs/cy.json
@@ -44,5 +44,10 @@
     "signup_form_button_submit": "Cofrestru",
     "common_back": "Yn ôl",
     "common_copy_to_clipboard": "Copio i'r clipfwrdd",
-    "signup_already_have_account": "Gyda chyfrif yn barod? Mewngofnodi!"
+    "signup_already_have_account": "Gyda chyfrif yn barod? Mewngofnodi!",
+    "prefs_legal_contact_title": "Cyswllt:",
+    "prefs_legal_name": "Enw",
+    "prefs_legal_email": "E-bost",
+    "prefs_legal_notice": "Hysbysiad Cyfreithiol",
+    "prefs_privacy_policy": "Polisi Preifatrwydd"
 }

--- a/web/public/static/langs/da.json
+++ b/web/public/static/langs/da.json
@@ -380,5 +380,10 @@
     "account_basics_phone_numbers_dialog_channel_sms": "SMS",
     "account_delete_dialog_billing_warning": "Hvis du sletter din konto, så annulleres dit abonnement med det samme. Du vil ikke længere have adgang til faktureringspanelet.",
     "prefs_notifications_min_priority_description_max": "Vis notifikationer, hvis prioritet er 5 (maks.)",
-    "account_upgrade_dialog_reservations_warning_other": "Det valgte niveau tillader færre reserverede emner end dit nuværende niveau. Før du ændrer dit niveau, <strong>slet venligst mindst {{count}} reservationer</strong>. Du kan fjerne reservationer i <Link>Indstillinger</Link>."
+    "account_upgrade_dialog_reservations_warning_other": "Det valgte niveau tillader færre reserverede emner end dit nuværende niveau. Før du ændrer dit niveau, <strong>slet venligst mindst {{count}} reservationer</strong>. Du kan fjerne reservationer i <Link>Indstillinger</Link>.",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Navn",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Juridisk meddelelse",
+    "prefs_privacy_policy": "Privatlivspolitik"
 }

--- a/web/public/static/langs/de.json
+++ b/web/public/static/langs/de.json
@@ -405,5 +405,10 @@
     "web_push_unknown_notification_body": "Du musst möglicherweise ntfy aktualisieren, indem du die Web App öffnest",
     "prefs_notifications_web_push_enabled_description": "Benachrichtigungen werden empfangen, auch wenn die Web App nicht geöffnet ist (via Web Push)",
     "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Bereitgestelltes Token kann nicht bearbeitet oder gelöscht werden",
-    "account_basics_cannot_edit_or_delete_provisioned_user": "Ein bereitgestellter Benutzer kann nicht bearbeitet oder gelöscht werden"
+    "account_basics_cannot_edit_or_delete_provisioned_user": "Ein bereitgestellter Benutzer kann nicht bearbeitet oder gelöscht werden",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Name",
+    "prefs_legal_email": "E-Mail",
+    "prefs_legal_notice": "Impressum",
+    "prefs_privacy_policy": "Datenschutzerklärung"
 }

--- a/web/public/static/langs/en.json
+++ b/web/public/static/langs/en.json
@@ -425,7 +425,7 @@
   "web_push_subscription_expiring_body": "Open ntfy to continue receiving notifications",
   "web_push_unknown_notification_title": "Unknown notification received from server",
   "web_push_unknown_notification_body": "You may need to update ntfy by opening the web app",
-  "prefs_legal_contact_title": "Content:",
+  "prefs_legal_contact_title": "Contact:",
   "prefs_legal_name": "Name",
   "prefs_legal_email": "Email",
   "prefs_legal_notice": "Legal Notice",

--- a/web/public/static/langs/en.json
+++ b/web/public/static/langs/en.json
@@ -424,5 +424,10 @@
   "web_push_subscription_expiring_title": "Notifications will be paused",
   "web_push_subscription_expiring_body": "Open ntfy to continue receiving notifications",
   "web_push_unknown_notification_title": "Unknown notification received from server",
-  "web_push_unknown_notification_body": "You may need to update ntfy by opening the web app"
+  "web_push_unknown_notification_body": "You may need to update ntfy by opening the web app",
+  "prefs_legal_contact_title": "Content:",
+  "prefs_legal_name": "Name",
+  "prefs_legal_email": "Email",
+  "prefs_legal_notice": "Legal Notice",
+  "prefs_privacy_policy": "Privacy Policy"
 }

--- a/web/public/static/langs/es.json
+++ b/web/public/static/langs/es.json
@@ -406,5 +406,10 @@
     "web_push_unknown_notification_title": "Notificación desconocida recibida del servidor",
     "web_push_unknown_notification_body": "Puede que necesites actualizar ntfy abriendo la aplicación web",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Un usuario provisionado no se puede editar o eliminar",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "No se puede editar o eliminar un token provisionado"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "No se puede editar o eliminar un token provisionado",
+    "prefs_legal_contact_title": "Contacto:",
+    "prefs_legal_name": "Nombre",
+    "prefs_legal_email": "Correo electrónico",
+    "prefs_legal_notice": "Aviso legal",
+    "prefs_privacy_policy": "Política de privacidad"
 }

--- a/web/public/static/langs/et.json
+++ b/web/public/static/langs/et.json
@@ -405,5 +405,10 @@
     "account_upgrade_dialog_reservations_warning_other": "Sinu praegune teenusepakett võimaldab senise paketiga võrreldes reserveerida vähem teemasid. Enne paketi muutmist <strong>palun esmalt kustuta vähemalt {{count}} reserveeringut</strong>. Seda saad <Link>teha siin</Link>.",
     "prefs_users_description": "Oma kaitstud teemade kasutajaid saad lisada ja eemaldada siin. Palun arvesta, et kasutajanimi ja salasõna on salvestatud veebibrauseri kohalikus andmeruumis.",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Eelsisestatud kasutajat ei saa muuta ega kustutada",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Eelsisestatud tunnusluba ei saa muuta ega kustutada"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Eelsisestatud tunnusluba ei saa muuta ega kustutada",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Nimi",
+    "prefs_legal_email": "E-post",
+    "prefs_legal_notice": "Juriidiline teave",
+    "prefs_privacy_policy": "Privaatsuspoliitika"
 }

--- a/web/public/static/langs/fa.json
+++ b/web/public/static/langs/fa.json
@@ -54,5 +54,10 @@
     "alert_notification_permission_required_description": "به مرورگر خود اجازه دهید تا اعلان‌های دسکتاپ را نمایش دهد",
     "alert_notification_permission_denied_title": "اعلان‌ها مسدود هستند",
     "alert_notification_ios_install_required_title": "لازم به نصب نسخه iOS است",
-    "alert_notification_ios_install_required_description": "برای فعال کردن اعلان‌ها در iOS، روی نماد اشتراک‌گذاری و افزودن به صفحه اصلی کلیک کنید"
+    "alert_notification_ios_install_required_description": "برای فعال کردن اعلان‌ها در iOS، روی نماد اشتراک‌گذاری و افزودن به صفحه اصلی کلیک کنید",
+    "prefs_legal_contact_title": "تماس:",
+    "prefs_legal_name": "نام",
+    "prefs_legal_email": "ایمیل",
+    "prefs_legal_notice": "اطلاعیه حقوقی",
+    "prefs_privacy_policy": "سیاست حفظ حریم خصوصی"
 }

--- a/web/public/static/langs/fi.json
+++ b/web/public/static/langs/fi.json
@@ -406,5 +406,10 @@
     "web_push_unknown_notification_body": "Voit joutua päivittämään ntfy:n avaamalla verkkosovelluksen",
     "notifications_actions_failed_notification": "Epäonnistunut toiminto",
     "subscribe_dialog_subscribe_use_another_background_info": "Ilmoituksia muilta palvelimilta ei vastaanoteta, mikäli verkkosovellus ei ole avoinna",
-    "prefs_notifications_web_push_enabled_description": "Ilmoituksia vastaanotetaan siitä huolimatta, että verkkosovellus ei ole käynnissä (Web Push:n kautta)"
+    "prefs_notifications_web_push_enabled_description": "Ilmoituksia vastaanotetaan siitä huolimatta, että verkkosovellus ei ole käynnissä (Web Push:n kautta)",
+    "prefs_legal_contact_title": "Yhteystiedot:",
+    "prefs_legal_name": "Nimi",
+    "prefs_legal_email": "Sähköposti",
+    "prefs_legal_notice": "Oikeudellinen huomautus",
+    "prefs_privacy_policy": "Tietosuojaseloste"
 }

--- a/web/public/static/langs/fr.json
+++ b/web/public/static/langs/fr.json
@@ -405,5 +405,10 @@
     "web_push_unknown_notification_title": "Notification inconnue reçue du serveur",
     "web_push_unknown_notification_body": "Il est possible que vous deviez mettre à jour ntfy en ouvrant l'application web",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Un utilisateur provisionné ne peut pas être modifié ou supprimé",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Impossible de modifier ou de supprimer le jeton provisionné"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Impossible de modifier ou de supprimer le jeton provisionné",
+    "prefs_legal_contact_title": "Contact :",
+    "prefs_legal_name": "Nom",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Mentions légales",
+    "prefs_privacy_policy": "Politique de confidentialité"
 }

--- a/web/public/static/langs/gl.json
+++ b/web/public/static/langs/gl.json
@@ -408,5 +408,10 @@
     "web_push_unknown_notification_body": "Poderías ter que actualizar ntfy abrindo a app web",
     "subscribe_dialog_subscribe_use_another_background_info": "As notificacións procedentes doutros servidores non se van recibir cando a app web estea pechada",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Unha usuaria predefinida non se pode editar ou eliminar",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Non se pode editar un token de usuaria predefinida"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Non se pode editar un token de usuaria predefinida",
+    "prefs_legal_contact_title": "Contacto:",
+    "prefs_legal_name": "Nome",
+    "prefs_legal_email": "Correo electrónico",
+    "prefs_legal_notice": "Aviso legal",
+    "prefs_privacy_policy": "Política de privacidade"
 }

--- a/web/public/static/langs/he.json
+++ b/web/public/static/langs/he.json
@@ -69,5 +69,10 @@
     "nav_button_subscribe": "הרשמה לנושא",
     "nav_button_muted": "התראות הושתקו",
     "nav_button_connecting": "מתחבר",
-    "nav_upgrade_banner_label": "שדרוג ל־ntfy Pro"
+    "nav_upgrade_banner_label": "שדרוג ל־ntfy Pro",
+    "prefs_legal_contact_title": "איש קשר:",
+    "prefs_legal_name": "שם",
+    "prefs_legal_email": "דואר אלקטרוני",
+    "prefs_legal_notice": "הודעה משפטית",
+    "prefs_privacy_policy": "מדיניות פרטיות"
 }

--- a/web/public/static/langs/hu.json
+++ b/web/public/static/langs/hu.json
@@ -405,5 +405,10 @@
     "web_push_subscription_expiring_title": "Az értesítések felfüggesztésre kerülnek",
     "web_push_subscription_expiring_body": "Nyissa meg az ntfy alkalmazást, hogy továbbra is értesítéseket kapjon",
     "web_push_unknown_notification_title": "Ismeretlen értesítés érkezett a szerverről",
-    "web_push_unknown_notification_body": "Előfordulhat, hogy a webalkalmazás megnyitásával frissítenie kell az ntfy-t"
+    "web_push_unknown_notification_body": "Előfordulhat, hogy a webalkalmazás megnyitásával frissítenie kell az ntfy-t",
+    "prefs_legal_contact_title": "Kapcsolat:",
+    "prefs_legal_name": "Név",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Jogi nyilatkozat",
+    "prefs_privacy_policy": "Adatvédelmi irányelvek"
 }

--- a/web/public/static/langs/id.json
+++ b/web/public/static/langs/id.json
@@ -406,5 +406,10 @@
     "web_push_unknown_notification_title": "Notifikasi yang tidak diketahui diterima dari server",
     "web_push_unknown_notification_body": "Anda mungkin harus memperbarui ntfy dengan membuka aplikasi web",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Pengguna yang telah ditetapkan tidak dapat diedit atau dihapus",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Tidak dapat mengedit atau menghapus token yang disediakan"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Tidak dapat mengedit atau menghapus token yang disediakan",
+    "prefs_legal_contact_title": "Kontak:",
+    "prefs_legal_name": "Nama",
+    "prefs_legal_email": "Email",
+    "prefs_legal_notice": "Pemberitahuan hukum",
+    "prefs_privacy_policy": "Kebijakan privasi"
 }

--- a/web/public/static/langs/it.json
+++ b/web/public/static/langs/it.json
@@ -405,5 +405,10 @@
     "account_tokens_dialog_expires_x_hours": "Il token scade tra {{hours}} ore",
     "prefs_reservations_table": "Tabella argomenti riservati",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Un utente autorizzato non può essere modificato o eliminato",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Impossibile modificare o eliminare il token fornito"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Impossibile modificare o eliminare il token fornito",
+    "prefs_legal_contact_title": "Contatto:",
+    "prefs_legal_name": "Nome",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Note legali",
+    "prefs_privacy_policy": "Informativa sulla privacy"
 }

--- a/web/public/static/langs/ja.json
+++ b/web/public/static/langs/ja.json
@@ -405,5 +405,10 @@
     "web_push_unknown_notification_title": "不明な通知を受信しました",
     "web_push_unknown_notification_body": "ウェブアプリを開いてntfyをアップデートする必要があります",
     "account_basics_cannot_edit_or_delete_provisioned_user": "自動作成されたユーザーの編集や削除はできません",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "自動作成されたトークンは編集や削除はできません"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "自動作成されたトークンは編集や削除はできません",
+    "prefs_legal_contact_title": "連絡先:",
+    "prefs_legal_name": "氏名",
+    "prefs_legal_email": "メールアドレス",
+    "prefs_legal_notice": "法的通知",
+    "prefs_privacy_policy": "プライバシーポリシー"
 }

--- a/web/public/static/langs/ko.json
+++ b/web/public/static/langs/ko.json
@@ -188,5 +188,10 @@
     "prefs_users_dialog_password_label": "비밀번호",
     "priority_max": "최상",
     "error_boundary_description": "이것은 당연히 발생되어서는 안됩니다. 굉장히 죄송합니다.<br/>가능하시다면 <githubLink>이 문제를 깃허브에 제보</githubLink>해 주시거나, <discordLink>디스코드 서버</discordLink>나 <matrixLink>Matrix</matrixLink>를 통해 알려주세요.",
-    "common_copy_to_clipboard": "클립보드에 복사"
+    "common_copy_to_clipboard": "클립보드에 복사",
+    "prefs_legal_contact_title": "연락처:",
+    "prefs_legal_name": "이름",
+    "prefs_legal_email": "이메일",
+    "prefs_legal_notice": "법적 고지",
+    "prefs_privacy_policy": "개인정보처리방침"
 }

--- a/web/public/static/langs/lv.json
+++ b/web/public/static/langs/lv.json
@@ -121,5 +121,10 @@
     "publish_dialog_other_features": "Citas funkcijas:",
     "publish_dialog_chip_call_label": "Tālruņa zvans",
     "publish_dialog_chip_delay_label": "Aizkavēt piegādi",
-    "publish_dialog_chip_topic_label": "Mainīt tēmu"
+    "publish_dialog_chip_topic_label": "Mainīt tēmu",
+    "prefs_legal_contact_title": "Kontaktinformācija:",
+    "prefs_legal_name": "Vārds",
+    "prefs_legal_email": "E-pasts",
+    "prefs_legal_notice": "Juridisks paziņojums",
+    "prefs_privacy_policy": "Privātuma politika"
 }

--- a/web/public/static/langs/mk.json
+++ b/web/public/static/langs/mk.json
@@ -96,5 +96,10 @@
     "notifications_none_for_any_title": "Не сте добиле никакви известувања.",
     "notifications_actions_failed_notification": "Неуспешно дејство",
     "notifications_none_for_topic_title": "Сè уште не сте добиле никакви известувања за оваа тема.",
-    "publish_dialog_filename_label": "Име на фајл"
+    "publish_dialog_filename_label": "Име на фајл",
+    "prefs_legal_contact_title": "Контакт:",
+    "prefs_legal_name": "Име",
+    "prefs_legal_email": "Е-пошта",
+    "prefs_legal_notice": "Правна напомена",
+    "prefs_privacy_policy": "Политика за приватност"
 }

--- a/web/public/static/langs/ms.json
+++ b/web/public/static/langs/ms.json
@@ -186,5 +186,10 @@
     "account_upgrade_dialog_button_pay_now": "Bayar sekarang dan langgan",
     "account_tokens_title": "Token akses",
     "account_tokens_description": "Gunakan token akses semasa menerbitkan dan melanggan melalui API ntfy, jadi anda tidak perlu menghantar bukti kelayakan akaun anda. Lihat <Link>dokumentasi</Link> untuk mengetahui lebih lanjut.",
-    "account_tokens_table_last_access_header": "Akses terakhir"
+    "account_tokens_table_last_access_header": "Akses terakhir",
+    "prefs_legal_contact_title": "Hubungi:",
+    "prefs_legal_name": "Nama",
+    "prefs_legal_email": "E-mel",
+    "prefs_legal_notice": "Notis undang-undang",
+    "prefs_privacy_policy": "Dasar privasi"
 }

--- a/web/public/static/langs/nb_NO.json
+++ b/web/public/static/langs/nb_NO.json
@@ -403,5 +403,10 @@
     "web_push_subscription_expiring_body": "Åpne ntfy for å fortsette å motta varslinger",
     "web_push_unknown_notification_title": "Ukjent varsel mottatt fra server",
     "web_push_unknown_notification_body": "Du må muligens oppdatere ntfy ved å åpne web-appen",
-    "account_usage_attachment_storage_description": "{{filesize}} pr. fil, slettet etter {{expiry}}"
+    "account_usage_attachment_storage_description": "{{filesize}} pr. fil, slettet etter {{expiry}}",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Navn",
+    "prefs_legal_email": "E-post",
+    "prefs_legal_notice": "Juridisk merknad",
+    "prefs_privacy_policy": "Personvernerklæring"
 }

--- a/web/public/static/langs/nl.json
+++ b/web/public/static/langs/nl.json
@@ -403,5 +403,10 @@
     "error_boundary_button_reload_ntfy": "Herlaad ntfy",
     "web_push_subscription_expiring_title": "Notificaties worden gepauzeerd",
     "web_push_subscription_expiring_body": "Open ntfy om weer notificaties te ontvangen",
-    "web_push_unknown_notification_title": "Onbekende notificatie ontvangen van de server"
+    "web_push_unknown_notification_title": "Onbekende notificatie ontvangen van de server",
+    "prefs_legal_contact_title": "Contact:",
+    "prefs_legal_name": "Naam",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Juridische kennisgeving",
+    "prefs_privacy_policy": "Privacybeleid"
 }

--- a/web/public/static/langs/pl.json
+++ b/web/public/static/langs/pl.json
@@ -409,5 +409,10 @@
     "prefs_appearance_theme_title": "Wygląd",
     "prefs_reservations_dialog_description": "Zastrzeżenie tematu daje użytkownikowi prawo własności do tego tematu i umożliwia zdefiniowanie uprawnień dostępu do tego tematu dla innych użytkowników.",
     "reservation_delete_dialog_description": "Usunięcie rezerwacji powoduje rezygnację z prawa własności do tematu i umożliwia innym jego zarezerwowanie. Istniejące wiadomości i załączniki można zachować lub usunąć.",
-    "web_push_unknown_notification_body": "Konieczne może być zaktualizowanie ntfy poprzez otwarcie aplikacji internetowej"
+    "web_push_unknown_notification_body": "Konieczne może być zaktualizowanie ntfy poprzez otwarcie aplikacji internetowej",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Imię i nazwisko",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Nota prawna",
+    "prefs_privacy_policy": "Polityka prywatności"
 }

--- a/web/public/static/langs/pt.json
+++ b/web/public/static/langs/pt.json
@@ -406,5 +406,10 @@
     "web_push_unknown_notification_title": "Notificação desconhecida recebida do servidor",
     "web_push_unknown_notification_body": "Talvez seja necessário atualizar o ntfy abrindo a aplicação da Web",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Não se pode editar ou eliminar um usuário predefinido",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Não se pode editar ou eliminar um token predefinido"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Não se pode editar ou eliminar um token predefinido",
+    "prefs_legal_contact_title": "Contato:",
+    "prefs_legal_name": "Nome",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Aviso legal",
+    "prefs_privacy_policy": "Política de privacidade"
 }

--- a/web/public/static/langs/pt_BR.json
+++ b/web/public/static/langs/pt_BR.json
@@ -406,5 +406,10 @@
     "web_push_unknown_notification_title": "Notificação desconhecida recebida do servidor",
     "web_push_unknown_notification_body": "Talvez seja necessário atualizar o ntfy abrindo o aplicativo da Web",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Um usuário provisionado não pode ser editado ou apagado",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Não é possível editar ou apagar o token provisionado"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Não é possível editar ou apagar o token provisionado",
+    "prefs_legal_contact_title": "Contato:",
+    "prefs_legal_name": "Nome",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Aviso legal",
+    "prefs_privacy_policy": "Política de privacidade"
 }

--- a/web/public/static/langs/ro.json
+++ b/web/public/static/langs/ro.json
@@ -360,5 +360,10 @@
     "priority_default": "implicit",
     "priority_high": "ridicat",
     "priority_max": "maxim",
-    "error_boundary_button_reload_ntfy": "Reîncarcă ntfy"
+    "error_boundary_button_reload_ntfy": "Reîncarcă ntfy",
+    "prefs_legal_contact_title": "Contact:",
+    "prefs_legal_name": "Nume",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Notă legală",
+    "prefs_privacy_policy": "Politică de confidențialitate"
 }

--- a/web/public/static/langs/ru.json
+++ b/web/public/static/langs/ru.json
@@ -405,5 +405,10 @@
     "prefs_appearance_theme_dark": "Тёмная",
     "prefs_appearance_theme_light": "Светлая",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Пользователя, созданного автоматически, нельзя изменить или удалить",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Автоматически созданный токен нельзя изменить или удалить"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Автоматически созданный токен нельзя изменить или удалить",
+    "prefs_legal_contact_title": "Контакт:",
+    "prefs_legal_name": "Имя",
+    "prefs_legal_email": "Эл. почта",
+    "prefs_legal_notice": "Правовая информация",
+    "prefs_privacy_policy": "Политика конфиденциальности"
 }

--- a/web/public/static/langs/sk.json
+++ b/web/public/static/langs/sk.json
@@ -408,5 +408,10 @@
     "alert_notification_permission_required_title": "Oznámenia sú vypnuté",
     "alert_notification_ios_install_required_description": "Kliknutím na Zdieľať a Pridať na domovskú obrazovku povolíte oznámenia v systéme iOS",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Prideleného používateľa nemožno upraviť ani odstrániť",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Pridelený token nemožno upraviť ani odstrániť"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Pridelený token nemožno upraviť ani odstrániť",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Meno",
+    "prefs_legal_email": "E-mail",
+    "prefs_legal_notice": "Právne upozornenie",
+    "prefs_privacy_policy": "Zásady ochrany osobných údajov"
 }

--- a/web/public/static/langs/sl.json
+++ b/web/public/static/langs/sl.json
@@ -112,5 +112,10 @@
     "publish_dialog_drop_file_here": "Povleci in spusti",
     "emoji_picker_search_placeholder": "Išči emoji",
     "emoji_picker_search_clear": "Ponastavi iskanje",
-    "subscribe_dialog_subscribe_title": "Naročite se na temo"
+    "subscribe_dialog_subscribe_title": "Naročite se na temo",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Ime",
+    "prefs_legal_email": "E-pošta",
+    "prefs_legal_notice": "Pravno obvestilo",
+    "prefs_privacy_policy": "Politika zasebnosti"
 }

--- a/web/public/static/langs/sq.json
+++ b/web/public/static/langs/sq.json
@@ -59,5 +59,10 @@
     "alert_notification_ios_install_required_title": "Instalimi i iOS-it detyrohet",
     "alert_notification_permission_denied_description": "Ju lutemi riaktivizoni ato në Browser-in tuaj",
     "nav_button_documentation": "Dokumentacion",
-    "alert_notification_permission_required_button": "Lejo tani"
+    "alert_notification_permission_required_button": "Lejo tani",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Emri",
+    "prefs_legal_email": "E-maili",
+    "prefs_legal_notice": "Njoftim ligjor",
+    "prefs_privacy_policy": "Politika e privatësisë"
 }

--- a/web/public/static/langs/sv.json
+++ b/web/public/static/langs/sv.json
@@ -405,5 +405,10 @@
     "prefs_notifications_web_push_disabled_description": "Meddelanden tas emot när webbappen körs (via WebSocket)",
     "web_push_unknown_notification_title": "Okänd notifikation mottagen från server",
     "account_basics_cannot_edit_or_delete_provisioned_user": "En provisionerad användare kan inte redigeras eller tas bort",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Kan inte redigera eller ta bort en provisionerad token"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Kan inte redigera eller ta bort en provisionerad token",
+    "prefs_legal_contact_title": "Kontakt:",
+    "prefs_legal_name": "Namn",
+    "prefs_legal_email": "E-post",
+    "prefs_legal_notice": "Juridiskt meddelande",
+    "prefs_privacy_policy": "Integritetspolicy"
 }

--- a/web/public/static/langs/ta.json
+++ b/web/public/static/langs/ta.json
@@ -403,5 +403,10 @@
     "web_push_subscription_expiring_title": "அறிவிப்புகள் இடைநிறுத்தப்படும்",
     "web_push_subscription_expiring_body": "தொடர்ந்து அறிவிப்புகளைப் பெற NTFY ஐத் திறக்கவும்",
     "web_push_unknown_notification_title": "சேவையகத்திலிருந்து அறியப்படாத அறிவிப்பு பெறப்பட்டது",
-    "web_push_unknown_notification_body": "வலை பயன்பாட்டைத் திறப்பதன் மூலம் நீங்கள் NTFY ஐ புதுப்பிக்க வேண்டியிருக்கலாம்"
+    "web_push_unknown_notification_body": "வலை பயன்பாட்டைத் திறப்பதன் மூலம் நீங்கள் NTFY ஐ புதுப்பிக்க வேண்டியிருக்கலாம்",
+    "prefs_legal_contact_title": "தொடர்புக்கு:",
+    "prefs_legal_name": "பெயர்",
+    "prefs_legal_email": "மின்னஞ்சல்",
+    "prefs_legal_notice": "சட்ட அறிவிப்பு",
+    "prefs_privacy_policy": "தனியுரிமைக் கொள்கை"
 }

--- a/web/public/static/langs/th.json
+++ b/web/public/static/langs/th.json
@@ -52,5 +52,10 @@
     "nav_button_subscribe": "สมัครรับหัวข้อ",
     "nav_button_muted": "ปิดการแจ้งเตือน",
     "nav_button_connecting": "การเชื่อมต่อ",
-    "nav_upgrade_banner_label": "อัพเกรดเป็น ntfy Pro"
+    "nav_upgrade_banner_label": "อัพเกรดเป็น ntfy Pro",
+    "prefs_legal_contact_title": "ติดต่อ:",
+    "prefs_legal_name": "ชื่อ",
+    "prefs_legal_email": "อีเมล",
+    "prefs_legal_notice": "ประกาศทางกฎหมาย",
+    "prefs_privacy_policy": "นโยบายความเป็นส่วนตัว"
 }

--- a/web/public/static/langs/tr.json
+++ b/web/public/static/langs/tr.json
@@ -405,5 +405,10 @@
     "web_push_unknown_notification_body": "Web uygulamasını açarak ntfy'yi güncellemeniz gerekebilir",
     "subscribe_dialog_subscribe_use_another_background_info": "Web uygulaması açık değilken diğer sunuculardan gelen bildirimler alınmayacaktır",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Yetkilendirilmiş kullanıcı düzenlenemez veya silinemez",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Sağlanmış belirteci düzenleyemez veya silemezsiniz"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Sağlanmış belirteci düzenleyemez veya silemezsiniz",
+    "prefs_legal_contact_title": "İletişim:",
+    "prefs_legal_name": "Ad",
+    "prefs_legal_email": "E-posta",
+    "prefs_legal_notice": "Yasal uyarı",
+    "prefs_privacy_policy": "Gizlilik politikası"
 }

--- a/web/public/static/langs/uk.json
+++ b/web/public/static/langs/uk.json
@@ -406,5 +406,10 @@
     "web_push_unknown_notification_body": "Можливо вам потрібно оновити ntfy шляхом відкриття вебзастосунку",
     "alert_notification_ios_install_required_title": "Необхідне встановлення на iOS",
     "account_basics_cannot_edit_or_delete_provisioned_user": "Автоматично створеного користувача не можна редагувати чи видалити",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Автоматично створений токен не можна редагувати чи видалити"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "Автоматично створений токен не можна редагувати чи видалити",
+    "prefs_legal_contact_title": "Контакти:",
+    "prefs_legal_name": "Ім'я",
+    "prefs_legal_email": "Електронна пошта",
+    "prefs_legal_notice": "Правова інформація",
+    "prefs_privacy_policy": "Політика конфіденційності"
 }

--- a/web/public/static/langs/uz.json
+++ b/web/public/static/langs/uz.json
@@ -23,5 +23,10 @@
     "signup_form_toggle_password_visibility": "Parol ko‘rinishini o‘zgartirish",
     "signup_already_have_account": "Hisobingiz bormi? Tizimga kiring!",
     "signup_disabled": "Ro‘yxatdan o‘tish o‘chirilgan",
-    "action_bar_account": "Hisob"
+    "action_bar_account": "Hisob",
+    "prefs_legal_contact_title": "Aloqa:",
+    "prefs_legal_name": "Ism",
+    "prefs_legal_email": "El. pochta",
+    "prefs_legal_notice": "Huquqiy ogohlantirish",
+    "prefs_privacy_policy": "Maxfiylik siyosati"
 }

--- a/web/public/static/langs/vi.json
+++ b/web/public/static/langs/vi.json
@@ -97,5 +97,10 @@
     "notifications_none_for_any_description": "Để gửi thông báo đến một topic, bạn chỉ cần dùng PUT hoặc POST đến URL của topic. Dưới đây là một ví dụ với một trong các topic của bạn.",
     "notifications_no_subscriptions_title": "Có vẻ như bạn chưa đăng ký topic nào.",
     "notifications_no_subscriptions_description": "Bấm vào liên kết \"{{linktext}}\" để tạo hoặc đăng ký một chủ đề. Sau đó, bạn có thể gửi tin nhắn qua PUT hoặc POST và sẽ nhận thông báo tại đây.",
-    "notifications_example": "Ví dụ"
+    "notifications_example": "Ví dụ",
+    "prefs_legal_contact_title": "Liên hệ:",
+    "prefs_legal_name": "Tên",
+    "prefs_legal_email": "Email",
+    "prefs_legal_notice": "Thông báo pháp lý",
+    "prefs_privacy_policy": "Chính sách bảo mật"
 }

--- a/web/public/static/langs/zh_Hans.json
+++ b/web/public/static/langs/zh_Hans.json
@@ -405,5 +405,10 @@
     "web_push_unknown_notification_title": "接收到未知通知",
     "web_push_unknown_notification_body": "你可能需要打开网页来更新ntfy",
     "account_basics_cannot_edit_or_delete_provisioned_user": "已设置的用户无法被编辑或删除",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "无法编辑或删除已设置的令牌"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "无法编辑或删除已设置的令牌",
+    "prefs_legal_contact_title": "联系方式：",
+    "prefs_legal_name": "姓名",
+    "prefs_legal_email": "电子邮箱",
+    "prefs_legal_notice": "法律声明",
+    "prefs_privacy_policy": "隐私政策"
 }

--- a/web/public/static/langs/zh_Hant.json
+++ b/web/public/static/langs/zh_Hant.json
@@ -405,5 +405,10 @@
     "web_push_unknown_notification_body": "你可能需要開啟網頁來更新 ntfy",
     "web_push_unknown_notification_title": "接收到不明通知",
     "account_basics_cannot_edit_or_delete_provisioned_user": "已佈建的使用者無法編輯或刪除",
-    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "無法編輯或刪除已佈建的權杖"
+    "account_tokens_table_cannot_delete_or_edit_provisioned_token": "無法編輯或刪除已佈建的權杖",
+    "prefs_legal_contact_title": "聯絡方式：",
+    "prefs_legal_name": "姓名",
+    "prefs_legal_email": "電子郵件",
+    "prefs_legal_notice": "法律聲明",
+    "prefs_privacy_policy": "隱私權政策"
 }

--- a/web/src/app/VersionChecker.js
+++ b/web/src/app/VersionChecker.js
@@ -52,6 +52,10 @@ class VersionChecker {
       }
 
       const data = await response.json();
+      if (data.legal_name) localStorage.setItem('operatorName', data.legal_name);
+      if (data.legal_email) localStorage.setItem('operatorEmail', data.legal_email);
+      if (data.privacy_policy_url) localStorage.setItem('privacyUrl', data.privacy_policy_url);
+      if (data.legal_notice_url) localStorage.setItem('imprintUrl', data.legal_notice_url);
       const currentHash = data.config_hash;
 
       if (currentHash && currentHash !== this.initialConfigHash) {

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -85,6 +85,8 @@ Navigation.width = navWidth;
 
 const NavList = (props) => {
   const theme = useTheme();
+  console.log("config keys:", Object.keys(config));
+  console.log("legal_name:", config.legal_name);
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
@@ -135,7 +137,7 @@ const NavList = (props) => {
     showNotificationContextNotSupportedBox;
 
   return (
-    <>
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <Toolbar sx={{ display: { xs: "none", sm: "block" } }} />
       <List component="nav" sx={{ paddingTop: { xs: 0, sm: alertVisible ? 0 : "" } }}>
         {versionChanged && <VersionUpdateBanner />}
@@ -147,9 +149,7 @@ const NavList = (props) => {
         {alertVisible && <Divider />}
         {!showSubscriptionsList && (
           <ListItemButton onClick={() => navigate(routes.app)} selected={location.pathname === config.app_root}>
-            <ListItemIcon>
-              <ChatBubble />
-            </ListItemIcon>
+            <ListItemIcon><ChatBubble /></ListItemIcon>
             <ListItemText primary={t("nav_button_all_notifications")} />
           </ListItemButton>
         )}
@@ -157,9 +157,7 @@ const NavList = (props) => {
           <>
             <ListSubheader>{t("nav_topics_title")}</ListSubheader>
             <ListItemButton onClick={() => navigate(routes.app)} selected={location.pathname === config.app_root}>
-              <ListItemIcon>
-                <ChatBubble />
-              </ListItemIcon>
+              <ListItemIcon><ChatBubble /></ListItemIcon>
               <ListItemText primary={t("nav_button_all_notifications")} />
             </ListItemButton>
             <SubscriptionList subscriptions={props.subscriptions} selectedSubscription={props.selectedSubscription} />
@@ -168,42 +166,28 @@ const NavList = (props) => {
         )}
         {session.exists() && (
           <ListItemButton onClick={handleAccountClick} selected={location.pathname === routes.account}>
-            <ListItemIcon>
-              <Person />
-            </ListItemIcon>
+            <ListItemIcon><Person /></ListItemIcon>
             <ListItemText primary={t("nav_button_account")} />
           </ListItemButton>
         )}
         <ListItemButton onClick={() => navigate(routes.settings)} selected={location.pathname === routes.settings}>
-          <ListItemIcon>
-            <SettingsIcon />
-          </ListItemIcon>
+          <ListItemIcon><SettingsIcon /></ListItemIcon>
           <ListItemText primary={t("nav_button_settings")} />
         </ListItemButton>
         <ListItemButton onClick={() => openUrl("/docs")}>
-          <ListItemIcon>
-            <ArticleIcon />
-          </ListItemIcon>
+          <ListItemIcon><ArticleIcon /></ListItemIcon>
           <ListItemText primary={t("nav_button_documentation")} />
         </ListItemButton>
         <ListItemButton onClick={() => props.onPublishMessageClick()}>
-          <ListItemIcon>
-            <Send />
-          </ListItemIcon>
+          <ListItemIcon><Send /></ListItemIcon>
           <ListItemText primary={t("nav_button_publish_message")} />
         </ListItemButton>
         <ListItemButton onClick={() => setSubscribeDialogOpen(true)}>
-          <ListItemIcon>
-            <AddIcon />
-          </ListItemIcon>
+          <ListItemIcon><AddIcon /></ListItemIcon>
           <ListItemText primary={t("nav_button_subscribe")} />
         </ListItemButton>
-        {showUpgradeBanner && (
-          // The text background gradient didn't seem to do well with switching between light/dark mode,
-          // So adding a `key` forces React to replace the entire component when the theme changes
-          <UpgradeBanner key={`upgrade-banner-${theme.palette.mode}`} mode={theme.palette.mode} />
-        )}
       </List>
+
       <SubscribeDialog
         key={`subscribeDialog${subscribeDialogKey}`} // Resets dialog when canceled/closed
         open={subscribeDialogOpen}
@@ -211,7 +195,64 @@ const NavList = (props) => {
         onCancel={handleSubscribeReset}
         onSuccess={handleSubscribeSubmit}
       />
-    </>
+
+      {showUpgradeBanner && (
+        // The text background gradient didn't seem to do well with switching between light/dark mode,
+        // So adding a `key` forces React to replace the entire component when the theme changes
+        <UpgradeBanner key={`upgrade-banner-${theme.palette.mode}`} mode={theme.palette.mode} />
+      )}
+
+
+
+      {(config.legal_name || config.legal_email || config.legal_notice_url || config.privacy_policy_url) && (
+        <Box sx={{ mt: "auto", p: 2, borderTop: "1px solid rgba(128,128,128,0.3)" }}>
+          {(config.legal_name || config.legal_email) && (
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="body2" sx={{ fontWeight: "bold", mb: 1 }}>
+                {t("prefs_legal_contact_title")}
+              </Typography>
+
+              {config.legal_name && (
+                <Typography variant="caption" display="block">
+                  <strong>{t("prefs_legal_name")}:</strong> {config.legal_name}
+                </Typography>
+              )}
+
+              {config.legal_email && (
+                <Typography variant="caption" display="block">
+                  <strong>{t("prefs_legal_email")}:</strong>{" "}
+                  <a href={`mailto:${config.legal_email}`} style={{ color: "#90caf9", textDecoration: "underline" }}>
+                    {config.legal_email}
+                  </a>
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {config.legal_notice_url && (
+            <Typography variant="caption" display="block">
+              <a
+                href={config.legal_notice_url.startsWith("http") ? config.legal_notice_url : `https://${config.legal_notice_url}`}
+                style={{ color: "#90caf9", textDecoration: "underline" }}
+                target="_blank" rel="noopener noreferrer">
+                {t("prefs_legal_notice")}
+              </a>
+            </Typography>
+          )}
+
+          {config.privacy_policy_url && (
+            <Typography variant="caption" display="block">
+              <a
+                href={config.privacy_policy_url.startsWith("http") ? config.privacy_policy_url : `https://${config.privacy_policy_url}`}
+                style={{ color: "#90caf9", textDecoration: "underline" }}
+                target="_blank" rel="noopener noreferrer">
+                {t("prefs_privacy_policy")}
+              </a>
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Box>
   );
 };
 

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -85,8 +85,6 @@ Navigation.width = navWidth;
 
 const NavList = (props) => {
   const theme = useTheme();
-  console.log("config keys:", Object.keys(config));
-  console.log("legal_name:", config.legal_name);
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();


### PR DESCRIPTION
This PR implements a customizable legal and contact information section for ntfy self-hosted instances.

To comply with legal requirements in certain jurisdictions (specifically Germany) for website operators to provide visible contact information, privacy policies, and legal notices (Imprint) this change introduces new configuration options in server.yml

<img width="271" height="1037" alt="Untitled" src="https://github.com/user-attachments/assets/5301f300-4656-49f7-b5b0-48e58268e274" />

Added support for the following optional fields in server.yml:

    legal-name: Operator or organization name.

    legal-email: Contact email address.

    privacy-policy-url: Link to the privacy policy.

    legal-notice-url: Link to the legal notice/imprint.
example .yml file:

listen: ":3001"
base_url: "http://localhost:3001"
legal-name: "randomguy"
legal-email: "test@example.com"
privacy-policy-url: "example.com"
legal-notice-url: "example.com" 

it won't appear if the fields are left blank and will only appear when one or more fields is provided  
i have also added translation for every language that was in the lang directory 

Closes #1606
Closes #1735 