### PR TITLE
Grant users access to their own sync topic under deny-all (fixes #733)

### DIFF
--- a/user/manager.go
+++ b/user/manager.go
@@ -639,6 +639,13 @@ func (a *Manager) Authorize(user *User, topic string, perm Permission) error {
 	if user != nil && user.Role == RoleAdmin {
 		return nil // Admin can do everything
 	}
+	// A user always has full access to their own sync topic, which the apps use
+	// to sync subscriptions/settings across devices. Without this, an
+	// auth-default-access of "deny-all" locks the user out of their own sync
+	// topic (no ACL entry is created for it at user creation). See #733.
+	if user != nil && user.SyncTopic != "" && topic == user.SyncTopic {
+		return nil
+	}
 	username := Everyone
 	if user != nil {
 		username = user.Name

--- a/user/manager_test.go
+++ b/user/manager_test.go
@@ -129,6 +129,13 @@ func TestManager_FullScenario_Default_DenyAll(t *testing.T) {
 		require.Nil(t, a.Authorize(ben, "announcements", PermissionRead))
 		require.Equal(t, ErrUnauthorized, a.Authorize(ben, "announcements", PermissionWrite))
 
+		// User has full access to their own sync topic, even under deny-all,
+		// but not to another user's sync topic (#733)
+		require.Nil(t, a.Authorize(ben, ben.SyncTopic, PermissionRead))
+		require.Nil(t, a.Authorize(ben, ben.SyncTopic, PermissionWrite))
+		require.Equal(t, ErrUnauthorized, a.Authorize(ben, john.SyncTopic, PermissionRead))
+		require.Equal(t, ErrUnauthorized, a.Authorize(ben, john.SyncTopic, PermissionWrite))
+
 		// User john should have
 		//  "deny" to mytopic_deny*,
 		//    "ro" to mytopic_ro*,


### PR DESCRIPTION
## Problem

Fixes #733.

On a self-hosted instance with `auth-default-access: deny-all` and an account-based (non-admin) user, the web app can't connect to its account **sync topic**: `wss://…/st_<id>/ws` returns **403**, which breaks cross-device subscription sync and logs a console error.

## Root cause

`Manager.Authorize` (`user/manager.go`) has no special case for a user's own sync topic, so the request falls through to `auth-default-access`:

```go
if user != nil && user.Role == RoleAdmin {
    return nil // Admin can do everything
}
...
} else if !found {
    return a.resolvePerms(a.config.DefaultAccess, perm) // ← deny-all denies st_<id>
}
```

User creation generates `SyncTopic` but never writes a matching ACL row, so under `deny-all` the owner is locked out of their own sync topic. Admin-role users are unaffected via the existing role bypass.

## Fix

Allow a user full access to their own `SyncTopic` in `Authorize`, right after the admin bypass:

```go
if user != nil && user.SyncTopic != "" && topic == user.SyncTopic {
    return nil
}
```

This fixes existing users without a migration (no ACL row needed).

### Alternative considered

Adding an ACL entry for the sync topic at user-creation time. I went with the `Authorize` special-case because it also fixes already-created users without a migration and keeps the "a user owns their sync topic" invariant in one place. Happy to switch to the auto-ACL approach if you'd prefer.

## Workaround (for anyone hitting this before a release)

Grant the user access to their own sync topic — find it via `GET /v1/account` (`sync_topic`), then `ntfy access <user> st_<id> rw`.

## Tests

Added a `user` package test: a non-admin user has read+write to their own sync topic under `deny-all`, but is still denied another user's sync topic. `go test ./user/` passes; `gofmt`/`go vet` clean.