### PR TITLE
Add Sifio to the Integrations page

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -43,6 +43,7 @@ I've added a ⭐ to projects or posts that have a significant following, or had 
 - [Miniflux](https://miniflux.app/docs/ntfy.html) - Minimalist and opinionated feed reader
 - [Beszel](https://beszel.dev/guide/notifications/ntfy) - Server monitoring platform
 - [Simple Observability](https://simpleobservability.com/docs/alerts/ntfy) - Server monitoring and observability platform
+- [Sifio](https://sifio.net) - Aggregate updates from RSS, social media, and other sources, then deliver them to ntfy, Slack, Notion and more
 
 ## Integration via HTTP/SMTP/etc.
 


### PR DESCRIPTION
Add Sifio to the Integrations / Projects page with a brief description and website link.