### PR TITLE
client: escape newlines with \n in X-Message header

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -19,6 +19,9 @@ type SubscribeOption = RequestOption
 
 // WithMessage sets the notification message. This is an alternative way to passing the message body.
 func WithMessage(message string) PublishOption {
+	if strings.Contains(message, "\n") {
+		return WithHeader("X-Message", strings.ReplaceAll(message, "\n", "\\n"))
+	}
 	return WithHeader("X-Message", message)
 }
 


### PR DESCRIPTION
fixes #1808