### PR TITLE
docs: add managed hosting option

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -24,6 +24,9 @@ If you like tutorials, check out :simple-youtube: [Kris Occhipinti's ntfy instal
 [Alex's Docker-based setup guide](https://blog.alexsguardian.net/posts/2023/09/12/selfhosting-ntfy/). Both are great
 resources to get started. _I am not affiliated with Kris or Alex, I just liked their video/post._
 
+## Managed hosting
+If you would rather not run ntfy yourself, [Zenith](https://zenith.hosting/host/ntfy?ref=gh) offers one-click managed ntfy hosting with storage, backups and TLS handled for you.
+
 ## Linux binaries
 Please check out the [releases page](https://github.com/binwiederhier/ntfy/releases) for binaries and
 deb/rpm packages.


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added ntfy to our marketplace, so this PR adds a small managed-hosting note to the install docs (links to https://zenith.hosting/host/ntfy?ref=gh).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting