### PR TITLE
Add ex_ntfy (Elixir library) to integrations

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -84,6 +84,7 @@ I've added a ⭐ to projects or posts that have a significant following, or had 
 - [symfony/ntfy-notifier](https://symfony.com/components/NtfyNotifier) ⭐ - Symfony Notifier integration for ntfy (PHP)
 - [ntfy-java](https://github.com/MaheshBabu11/ntfy-java/) - A Java package to interact with a ntfy server (Java)
 - [aiontfy](https://github.com/tr4nt0r/aiontfy) - Asynchronous client library for publishing and subscribing to ntfy (Python)
+- [ex_ntfy](https://github.com/houllette/ex_ntfy) - Elixir SDK covering publishing, polling, and streaming subscriptions for ntfy servers (Elixir)
 
 ## CLIs + GUIs
 


### PR DESCRIPTION
Adds [ex_ntfy](https://github.com/houllette/ex_ntfy) to the Libraries section — an Elixir SDK covering the publish API (all options, attachments, templates, the update/clear/delete lifecycle), one-shot polling, and long-lived streaming subscriptions (ndjson/SSE/raw/WebSocket) with automatic reconnect-and-resume.

- Hex package: https://hex.pm/packages/ex_ntfy
- Docs: https://hexdocs.pm/ex_ntfy
- MIT licensed; tested against ntfy.sh (opt-in live suite) as well as a fully stubbed unit suite

Thanks for ntfy! 🙏