### PR TITLE
Return ntfy error code and message in headers on failed WebSocket subscriptions

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2078,6 +2078,12 @@ and the [ntfy Android app](https://github.com/binwiederhier/ntfy-android/release
 
 ## Not released yet
 
+### ntfy server v2.28.0 (UNRELEASED)
+
+**Bug fixes + maintenance:**
+
+* Failed WebSocket subscriptions (e.g. auth failures) now return the ntfy error code and message in the `X-Ntfy-Error-Code` and `X-Ntfy-Error` response headers, alongside the proper HTTP status code, so clients can distinguish real failures from a `200` page returned by a proxy ([#535](https://github.com/binwiederhier/ntfy/issues/535), thanks to [@alexhorner](https://github.com/alexhorner) for reporting)
+
 ### ntfy iOS app v1.8.0 (UNRELEASED)
 
 **Features:**

--- a/server/server.go
+++ b/server/server.go
@@ -532,8 +532,16 @@ func (s *Server) handleError(w http.ResponseWriter, r *http.Request, v *visitor,
 		// Write error response only if the connection was not hijacked yet. Bytes written to hijacked
 		// connections are WebSocket frames, not HTTP, and will cause "http: response.WriteHeader on hijacked
 		// connection" log spam.
+		//
+		// If the error happened before the upgrade completed, the connection is still a regular HTTP
+		// connection, so we can return the actual HTTP status code (e.g. 401/403) instead of a bogus 200,
+		// along with the ntfy error code and message in headers. This lets WebSocket clients distinguish
+		// failures from a successful upgrade (101) and from unrelated 2xx pages returned by proxies (the
+		// error body is not readable by most WebSocket clients). See binwiederhier/ntfy#535.
 		var postUpgradeErr *errWebSocketPostUpgrade
 		if !errors.As(err, &postUpgradeErr) {
+			w.Header().Set("X-Ntfy-Error-Code", fmt.Sprintf("%d", httpErr.Code))
+			w.Header().Set("X-Ntfy-Error", httpErr.Message)
 			w.WriteHeader(httpErr.HTTPCode)
 		}
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5134,6 +5134,53 @@ func TestServer_HandleError_SkipsWriteHeaderOnHijackedConnection(t *testing.T) {
 	})
 }
 
+func TestServer_SubscribeWS_Failure_ReturnsErrorCodeAndHeaders(t *testing.T) {
+	// Regression test for binwiederhier/ntfy#535: a WebSocket subscription that fails before the
+	// upgrade completes (e.g. auth failure) must return the real HTTP status code (not 200) along
+	// with the ntfy error code and message in headers, so clients can distinguish failures.
+	forEachBackend(t, func(t *testing.T, databaseURL string) {
+		c := newTestConfigWithAuthFile(t, databaseURL)
+		c.AuthDefault = user.PermissionDenyAll
+		s := newTestServer(t, c)
+
+		require.Nil(t, s.userManager.AddUser("ben", "ben", user.RoleUser, false))
+		require.Nil(t, s.userManager.AllowAccess("ben", "sometopic", user.PermissionReadWrite)) // Not mytopic!
+
+		response := request(t, s, "GET", "/mytopic/ws", "", map[string]string{
+			"Authorization": util.BasicAuth("ben", "ben"),
+			"Upgrade":       "websocket",
+			"Connection":    "Upgrade",
+		})
+		require.Equal(t, 403, response.Code) // Not 200!
+		require.Equal(t, "40301", response.Header().Get("X-Ntfy-Error-Code"))
+		require.Equal(t, "forbidden", response.Header().Get("X-Ntfy-Error"))
+	})
+}
+
+func TestServer_HandleError_WebSocketErrorHeaders(t *testing.T) {
+	// Ensure the ntfy error code/message headers are set for pre-upgrade WebSocket errors, but not
+	// for post-upgrade (hijacked) errors, where the connection can no longer carry HTTP headers.
+	forEachBackend(t, func(t *testing.T, databaseURL string) {
+		s := newTestServer(t, newTestConfig(t, databaseURL))
+		r, _ := http.NewRequest("GET", "/mytopic/ws", nil)
+		r.Header.Set("Upgrade", "websocket")
+		r.Header.Set("Connection", "Upgrade")
+		v := newVisitor(s.config, s.messageCache, s.userManager, netip.MustParseAddr("1.2.3.4"), nil)
+
+		// Pre-upgrade error: headers must be present
+		mock := newMockResponseWriter()
+		s.handleError(mock, r, v, errHTTPBadRequestWebSocketsUpgradeHeaderMissing)
+		require.Equal(t, "40016", mock.Header().Get("X-Ntfy-Error-Code"))
+		require.Equal(t, "invalid request: client not using the websocket protocol", mock.Header().Get("X-Ntfy-Error"))
+
+		// Post-upgrade error: connection is hijacked, no headers may be written
+		mock = newMockResponseWriter()
+		s.handleError(mock, r, v, &errWebSocketPostUpgrade{errors.New("websocket: close 1000 (normal)")})
+		require.Empty(t, mock.Header().Get("X-Ntfy-Error-Code"))
+		require.Empty(t, mock.Header().Get("X-Ntfy-Error"))
+	})
+}
+
 func TestServer_Publish_InvalidUTF8InBody(t *testing.T) {
 	// All byte sequences from production logs, sent as message body
 	tests := []struct {


### PR DESCRIPTION
Failed WebSocket subscriptions already return the proper HTTP status code (e.g. 401/403) when the failure happens before the upgrade completes — but clients still cannot read *why* it failed (the JSON error body is not consumable by most WebSocket clients, which reject anything that is not a `101`), and they cannot tell a genuine ntfy error apart from a `200` page returned by an intermediary proxy. This is the "indistinguishable" part of #535.

This completes the suggestion from the issue thread by adding `X-Ntfy-Error-Code` (ntfy error code) and `X-Ntfy-Error` (message) response headers in the pre-upgrade WebSocket error path, mirroring the JSON body fields. Their presence lets clients distinguish real ntfy failures from proxy responses. Post-upgrade (hijacked) errors are left untouched via the existing `errWebSocketPostUpgrade` guard, since the connection can no longer carry HTTP headers.

Adds an end-to-end test (auth-failed `/ws` returns 403 + headers) and a unit test covering the pre- vs post-upgrade header behavior; existing hijacked-connection test still green.

Happy to adjust header naming/shape if you prefer a different form.

Fixes #535