### PR TITLE
Cancel all of a user's subscribers on access reset / user delete

### DIFF
--- a/server/topic.go
+++ b/server/topic.go
@@ -153,14 +153,16 @@ func (t *topic) CancelSubscribersExceptUser(exceptUserID string) {
 	}
 }
 
-// CancelSubscriberUser kills the subscriber with the given user ID
+// CancelSubscriberUser kills all subscribers with the given user ID. A single user may hold
+// multiple subscriptions on a topic (e.g. several tabs/devices), so we must cancel every match:
+// this is called from the access-reset and user-delete paths, where leaving any of the user's
+// subscriptions connected would keep delivering messages the user is no longer allowed to see.
 func (t *topic) CancelSubscriberUser(userID string) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	for _, s := range t.subscribers {
 		if s.userID == userID {
 			t.cancelUserSubscriber(s)
-			return
 		}
 	}
 }

--- a/server/topic_test.go
+++ b/server/topic_test.go
@@ -45,13 +45,20 @@ func TestTopic_CancelSubscribersUser(t *testing.T) {
 	cancelFn2 := func() {
 		canceled2.Store(true)
 	}
+	// u_phil holds two subscriptions (e.g. two tabs/devices); both must be canceled.
+	canceled3 := atomic.Bool{}
+	cancelFn3 := func() {
+		canceled3.Store(true)
+	}
 	to := newTopic("mytopic")
 	to.Subscribe(subFn, "u_another", cancelFn1)
 	to.Subscribe(subFn, "u_phil", cancelFn2)
+	to.Subscribe(subFn, "u_phil", cancelFn3)
 
 	to.CancelSubscriberUser("u_phil")
 	require.False(t, canceled1.Load())
 	require.True(t, canceled2.Load())
+	require.True(t, canceled3.Load())
 }
 
 func TestTopic_Keepalive(t *testing.T) {


### PR DESCRIPTION
As discussed by email — thanks for the quick reply.

### What
`topic.CancelSubscriberUser` returned after canceling the **first** matching subscriber:

```go
for _, s := range t.subscribers {
    if s.userID == userID {
        t.cancelUserSubscriber(s)
        return   // <- stops after the first match
    }
}
```

A single user commonly holds **several** subscriptions on one topic (multiple tabs/devices/stream+WS). This function is the teardown used by:

- `handleAccessReset` → `killUserSubscriber` (when an admin **resets/revokes** a user's access to a topic), and
- `handleUsersDelete` → `killUserSubscriber(u, "*")` (when a user is **deleted**).

So after a revoke or a delete, only one of the user's subscriptions was canceled; the rest stayed connected and **kept receiving that topic's future messages** even though the user was no longer authorized. Sibling function `CancelSubscribersExceptUser` already loops over all matches — this one just needs the same.

### Fix
Drop the early `return` so every matching subscriber is canceled, and extend `TestTopic_CancelSubscribersUser` to cover a user with two subscriptions on the same topic (fails before, passes after).

### Related (not in this PR — your call)
While looking at this, a few adjacent spots you may want to consider separately:
- `handleAccessAllow` lowering a permission to deny doesn't tear down existing subscribers (only `handleAccessReset` does);
- `publishToWebPushEndpoints` sends to stored WebPush endpoints by topic without re-checking authorization, and deleting a user doesn't remove their WebPush rows — so a revoked/deleted user can still be reached via WebPush.

Happy to follow up on those if you'd like them addressed too.

---
<sub>Found with [Argo](https://github.com/gigioneggiando/argo), my LLM-native security auditor, then hand-verified. Reporter: [@gigioneggiando](https://github.com/gigioneggiando).</sub>