### PR TITLE
Add action and template directories to Dockerfile-build

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -48,6 +48,9 @@ ADD ./webpush ./webpush
 ADD ./attachment ./attachment
 ADD ./mail ./mail
 ADD ./s3 ./s3
+ADD ./action ./action
+ADD ./template/gotext ./template/gotext
+
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server
 
 FROM alpine


### PR DESCRIPTION
Added new directories for action and template to the build process. (same fix as https://github.com/binwiederhier/ntfy/commit/9ccad9da2e6674f43239d332bfb3453095b4869c)

without these directories, the docker build currently fails with
>1.646 server/server.go:32:2: no required module provides package heckel.io/ntfy/v2/action; to add it:
1.646   go get heckel.io/ntfy/v2/action
1.646 server/server_template.go:15:2: no required module provides package heckel.io/ntfy/v2/template/gotext; to add it:
1.646   go get heckel.io/ntfy/v2/template/gotext


## testing
```
docker build -t ntfy -f ./Dockerfile-build .
``` 