### PR TITLE
fix(ios): set explicit APNS sound on alert pushes (#1562)

### DIFF
--- a/server/apns_sound_export_test.go
+++ b/server/apns_sound_export_test.go
@@ -1,0 +1,143 @@
+//go:build !nofirebase
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"heckel.io/ntfy/v2/model"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExportAPNSPayloadsForSim writes simctl-compatible .apns files from the
+// real server toFirebaseMessage path so we can verify sound on the simulator.
+func TestExportAPNSPayloadsForSim(t *testing.T) {
+	outDir := os.Getenv("APNS_EXPORT_DIR")
+	if outDir == "" {
+		t.Skip("set APNS_EXPORT_DIR to export payloads")
+	}
+	require.NoError(t, os.MkdirAll(outDir, 0o755))
+
+	type caseDef struct {
+		name     string
+		build    func() *model.Message
+		auther   *testAuther
+		wantKey  string // "sound" or "critical" or "none"
+	}
+	cases := []caseDef{
+		{
+			name: "normal_default_sound",
+			build: func() *model.Message {
+				m := model.NewDefaultMessage("probe-topic", "normal message with default sound")
+				m.Title = "ntfy #1562 normal"
+				m.Priority = 3
+				return m
+			},
+			auther:  &testAuther{Allow: true},
+			wantKey: "sound",
+		},
+		{
+			name: "priority5_max_sound",
+			build: func() *model.Message {
+				m := model.NewDefaultMessage("probe-topic", "max priority message")
+				m.Title = "ntfy #1562 max"
+				m.Priority = 5
+				return m
+			},
+			auther:  &testAuther{Allow: true},
+			wantKey: "sound",
+		},
+		{
+			name: "priority1_silent",
+			build: func() *model.Message {
+				m := model.NewDefaultMessage("probe-topic", "min priority silent")
+				m.Title = "ntfy #1562 min"
+				m.Priority = 1
+				return m
+			},
+			auther:  &testAuther{Allow: true},
+			wantKey: "none",
+		},
+		{
+			name: "reserved_topic_poll_request_sound",
+			build: func() *model.Message {
+				// Auth denied → poll_request "New message" — was silent before the fix
+				m := model.NewDefaultMessage("reserved-topic", "secret body")
+				m.Title = "secret title"
+				m.Priority = 3
+				return m
+			},
+			auther:  &testAuther{Allow: false},
+			wantKey: "sound",
+		},
+		{
+			name: "pre_fix_shape_no_sound_control",
+			build: func() *model.Message {
+				// Used only as control comparison; we strip sound after export in the harness
+				m := model.NewDefaultMessage("probe-topic", "control without sound key")
+				m.Title = "control silent"
+				m.Priority = 3
+				return m
+			},
+			auther:  &testAuther{Allow: true},
+			wantKey: "sound",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.build()
+			fbm, err := toFirebaseMessage(m, tc.auther)
+			require.NoError(t, err)
+			require.NotNil(t, fbm.APNS)
+			require.NotNil(t, fbm.APNS.Payload)
+			require.NotNil(t, fbm.APNS.Payload.Aps)
+
+			switch tc.wantKey {
+			case "sound":
+				require.Equal(t, "default", fbm.APNS.Payload.Aps.Sound)
+			case "critical":
+				require.NotNil(t, fbm.APNS.Payload.Aps.CriticalSound)
+			case "none":
+				require.Empty(t, fbm.APNS.Payload.Aps.Sound)
+				require.Nil(t, fbm.APNS.Payload.Aps.CriticalSound)
+			}
+
+			// Build a simctl-compatible payload mirroring FCM→APNS shape
+			aps := map[string]any{
+				"mutable-content": 1,
+				"alert": map[string]any{
+					"title": fbm.APNS.Payload.Aps.Alert.Title,
+					"body":  fbm.APNS.Payload.Aps.Alert.Body,
+				},
+			}
+			if cs := fbm.APNS.Payload.Aps.CriticalSound; cs != nil {
+				// APNS critical sound object (takes precedence over Sound string)
+				aps["sound"] = map[string]any{
+					"critical": 1,
+					"name":     cs.Name,
+					"volume":   cs.Volume,
+				}
+			} else if fbm.APNS.Payload.Aps.Sound != "" {
+				aps["sound"] = fbm.APNS.Payload.Aps.Sound
+			}
+			payload := map[string]any{
+				"Simulator Target Bundle": "com.ntfyfix.NotifSoundProbe",
+				"aps":                     aps,
+			}
+			// include custom data keys like FCM does
+			for k, v := range fbm.APNS.Payload.CustomData {
+				payload[k] = v
+			}
+			b, err := json.MarshalIndent(payload, "", "  ")
+			require.NoError(t, err)
+			path := filepath.Join(outDir, tc.name+".apns")
+			require.NoError(t, os.WriteFile(path, b, 0o644))
+			fmt.Println("wrote", path)
+		})
+	}
+}

--- a/server/server_firebase.go
+++ b/server/server_firebase.go
@@ -236,23 +236,45 @@ func maybeTruncateFCMMessage(m *messaging.Message) *messaging.Message {
 // createAPNSAlertConfig creates an APNS config for iOS notifications that show up as an alert (only relevant for iOS).
 // We must set the Alert struct ("alert"), and we need to set MutableContent ("mutable-content"), so the Notification Service
 // Extension in iOS can modify the message.
+//
+// We also set an explicit sound for user-visible alerts. Omitting aps.sound makes iOS treat the notification as silent;
+// on iOS 26.2+ that has been observed to leave notifications muted and can interfere with other apps' notification audio
+// (see https://github.com/binwiederhier/ntfy/issues/1562). Priority 1 ("min") stays silent by design.
 func createAPNSAlertConfig(m *model.Message, data map[string]string) *messaging.APNSConfig {
 	apnsData := make(map[string]any)
 	for k, v := range data {
 		apnsData[k] = v
 	}
+	aps := &messaging.Aps{
+		MutableContent: true,
+		Alert: &messaging.ApsAlert{
+			Title: m.Title,
+			Body:  maybeTruncateAPNSBodyMessage(m.Message),
+		},
+	}
+	setAPNSAlertSound(aps, m.Priority)
 	return &messaging.APNSConfig{
 		Payload: &messaging.APNSPayload{
 			CustomData: apnsData,
-			Aps: &messaging.Aps{
-				MutableContent: true,
-				Alert: &messaging.ApsAlert{
-					Title: m.Title,
-					Body:  maybeTruncateAPNSBodyMessage(m.Message),
-				},
-			},
+			Aps:        aps,
 		},
 	}
+}
+
+// setAPNSAlertSound attaches the appropriate iOS notification sound for the given priority.
+//   - priority 1 (min): no sound (silent, matches Android "min" behavior)
+//   - all other priorities (including default/0 and max/5): system default sound
+//
+// Note: we intentionally use a plain "default" sound string rather than CriticalSound for
+// priority 5. Critical alerts require a special iOS entitlement the ntfy app may not have;
+// sending a critical sound dictionary without that entitlement can fail to play audio.
+// Explicit aps.sound is what fixes silent notifications on iOS 26.2+ (#1562).
+func setAPNSAlertSound(aps *messaging.Aps, priority int) {
+	if priority == 1 {
+		// Explicit silent: leave Sound unset.
+		return
+	}
+	aps.Sound = "default"
 }
 
 // createAPNSBackgroundConfig creates an APNS config for a silent background message (only relevant for iOS). Apple only

--- a/server/server_firebase_test.go
+++ b/server/server_firebase_test.go
@@ -168,6 +168,7 @@ func TestToFirebaseMessage_Message_Normal_Allowed(t *testing.T) {
 		Payload: &messaging.APNSPayload{
 			Aps: &messaging.Aps{
 				MutableContent: true,
+				Sound:          "default",
 				Alert: &messaging.ApsAlert{
 					Title: "some title",
 					Body:  "this is a message",
@@ -248,6 +249,95 @@ func TestToFirebaseMessage_Message_Normal_Not_Allowed(t *testing.T) {
 	}, fbm.Data)
 	require.Equal(t, "", fbm.APNS.Payload.Aps.Alert.Title)
 	require.Equal(t, "New message", fbm.APNS.Payload.Aps.Alert.Body)
+	// Reserved/auth topics become poll_request but keep priority 5 → still audible
+	require.Equal(t, "default", fbm.APNS.Payload.Aps.Sound)
+	require.Nil(t, fbm.APNS.Payload.Aps.CriticalSound)
+}
+
+func TestToFirebaseMessage_Message_MaxPriority_Allowed(t *testing.T) {
+	m := model.NewDefaultMessage("mytopic", "this is a max-priority message")
+	m.Priority = 5
+	m.Title = "max title"
+
+	fbm, err := toFirebaseMessage(m, &testAuther{Allow: true})
+	require.Nil(t, err)
+	require.Equal(t, "mytopic", fbm.Topic)
+	require.Equal(t, &messaging.AndroidConfig{
+		Priority: "high",
+	}, fbm.Android)
+	require.Equal(t, &messaging.APNSConfig{
+		Payload: &messaging.APNSPayload{
+			Aps: &messaging.Aps{
+				MutableContent: true,
+				Sound:          "default",
+				Alert: &messaging.ApsAlert{
+					Title: "max title",
+					Body:  "this is a max-priority message",
+				},
+			},
+			CustomData: map[string]any{
+				"id":           m.ID,
+				"time":         fmt.Sprintf("%d", m.Time),
+				"event":        "message",
+				"topic":        "mytopic",
+				"sequence_id":  "",
+				"priority":     "5",
+				"tags":         "",
+				"click":        "",
+				"icon":         "",
+				"title":        "max title",
+				"message":      "this is a max-priority message",
+				"content_type": "",
+				"encoding":     "",
+			},
+		},
+	}, fbm.APNS)
+	require.Nil(t, fbm.APNS.Payload.Aps.CriticalSound)
+}
+
+func TestToFirebaseMessage_Message_MinPriority_Silent(t *testing.T) {
+	m := model.NewDefaultMessage("mytopic", "quiet message")
+	m.Priority = 1
+	m.Title = "min"
+
+	fbm, err := toFirebaseMessage(m, &testAuther{Allow: true})
+	require.Nil(t, err)
+	require.Nil(t, fbm.Android)
+	require.Empty(t, fbm.APNS.Payload.Aps.Sound)
+	require.Nil(t, fbm.APNS.Payload.Aps.CriticalSound)
+	require.Equal(t, "min", fbm.APNS.Payload.Aps.Alert.Title)
+	require.Equal(t, "quiet message", fbm.APNS.Payload.Aps.Alert.Body)
+}
+
+func TestToFirebaseMessage_Message_DefaultPriority_HasSound(t *testing.T) {
+	// Priority 0 / unset should still get default sound (not silent).
+	m := model.NewDefaultMessage("mytopic", "default priority message")
+	require.Equal(t, 0, m.Priority)
+
+	fbm, err := toFirebaseMessage(m, nil)
+	require.Nil(t, err)
+	require.Equal(t, "default", fbm.APNS.Payload.Aps.Sound)
+	require.Nil(t, fbm.APNS.Payload.Aps.CriticalSound)
+}
+
+func TestSetAPNSAlertSound(t *testing.T) {
+	cases := []struct {
+		priority  int
+		wantSound string
+	}{
+		{priority: 0, wantSound: "default"},
+		{priority: 1, wantSound: ""},
+		{priority: 2, wantSound: "default"},
+		{priority: 3, wantSound: "default"},
+		{priority: 4, wantSound: "default"},
+		{priority: 5, wantSound: "default"},
+	}
+	for _, tc := range cases {
+		aps := &messaging.Aps{}
+		setAPNSAlertSound(aps, tc.priority)
+		require.Equal(t, tc.wantSound, aps.Sound, "priority %d", tc.priority)
+		require.Nil(t, aps.CriticalSound, "priority %d", tc.priority)
+	}
 }
 
 func TestToFirebaseMessage_PollRequest(t *testing.T) {
@@ -260,6 +350,7 @@ func TestToFirebaseMessage_PollRequest(t *testing.T) {
 		Payload: &messaging.APNSPayload{
 			Aps: &messaging.Aps{
 				MutableContent: true,
+				Sound:          "default",
 				Alert: &messaging.ApsAlert{
 					Title: "",
 					Body:  "New message",


### PR DESCRIPTION
iOS 26.2+ treats alert pushes without aps.sound as silent, which left ntfy notifications muted and could disrupt other apps' notification audio.

createAPNSAlertConfig now sets aps.sound = "default" for all user-visible alerts except priority 1 (min), including poll_request paths used for reserved/auth topics. Unit tests cover normal, max, min, and denied-auth cases; export helper supports simulator sound verification.