### PR TITLE
add tzdata to docker arm build

### DIFF
--- a/Dockerfile-arm
+++ b/Dockerfile-arm
@@ -9,9 +9,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0, GPL-2.0"
 LABEL org.opencontainers.image.title="ntfy"
 LABEL org.opencontainers.image.description="Send push notifications to your phone or desktop using PUT/POST"
 
-# Alpine does not support adding "tzdata" on ARM anymore, see
-# https://github.com/binwiederhier/ntfy/issues/894
-
+RUN apk add --no-cache tzdata
 COPY ntfy /usr/bin
 
 EXPOSE 80/tcp


### PR DESCRIPTION
#894 docker arm now builds successfully with tzdata package.