### PR TITLE
Dockerfile optimizations and macOS build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,52 @@
+FROM golang:1.25-bookworm AS builder
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG NODE_MAJOR=24
+
+RUN apt-get update && apt-get install -y \
+       build-essential ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" >> /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y \
+      nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+ADD Makefile .
+
+# web
+ADD ./web/package.json ./web/package-lock.json ./web/
+RUN --mount=type=cache,target=/root/.npm make web-deps
+ADD ./web ./web
+RUN make web-build
+
+# cli & server
+ADD go.mod go.sum main.go ./
+ADD ./client ./client
+ADD ./cmd ./cmd
+ADD ./log ./log
+ADD ./server ./server
+ADD ./user ./user
+ADD ./util ./util
+ADD ./payments ./payments
+ADD ./db ./db
+ADD ./message ./message
+ADD ./model ./model
+ADD ./webpush ./webpush
+ADD ./attachment ./attachment
+ADD ./mail ./mail
+ADD ./s3 ./s3
+ADD ./action ./action
+ADD ./template/gotext ./template/gotext
+
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server
+
 FROM alpine
+
+ARG VERSION=dev
 
 LABEL org.opencontainers.image.authors="philipp.heckel@gmail.com"
 LABEL org.opencontainers.image.url="https://ntfy.sh/"
@@ -8,9 +56,9 @@ LABEL org.opencontainers.image.vendor="Philipp C. Heckel"
 LABEL org.opencontainers.image.licenses="Apache-2.0, GPL-2.0"
 LABEL org.opencontainers.image.title="ntfy"
 LABEL org.opencontainers.image.description="Send push notifications to your phone or desktop using PUT/POST"
+LABEL org.opencontainers.image.version="$VERSION"
 
-RUN apk add --no-cache tzdata
-COPY ntfy /usr/bin
+COPY --from=builder /app/dist/ntfy_linux_server/ntfy /usr/bin/ntfy
 
 EXPOSE 80/tcp
 ENTRYPOINT ["ntfy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ ADD ./attachment ./attachment
 ADD ./mail ./mail
 ADD ./s3 ./s3
 ADD ./action ./action
+ADD ./ban ./ban
+ADD ./metrics ./metrics
+ADD ./twilio ./twilio
 ADD ./template/gotext ./template/gotext
 
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,12 @@ ADD ./template/gotext ./template/gotext
 
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server
 
-FROM alpine
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      tzdata \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG VERSION=dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,8 @@ LABEL org.opencontainers.image.version="$VERSION"
 
 COPY --from=builder /app/dist/ntfy_linux_server/ntfy /usr/bin/ntfy
 
-EXPOSE 80/tcp
+ENV NTFY_LISTEN_HTTP=:10000
+
+EXPOSE 10000/tcp
 ENTRYPOINT ["ntfy"]
+CMD ["serve"]

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ web-build:
 	cd web \
 		&& $(NPM) run build \
 		&& mv build/index.html build/app.html \
+		&& mkdir -p ../server \
 		&& rm -rf ../server/site \
 		&& mv build ../server/site \
 		&& rm \

--- a/cmd/publish_test.go
+++ b/cmd/publish_test.go
@@ -123,10 +123,10 @@ func TestCLI_Publish_Wait_PID_And_Cmd(t *testing.T) {
 
 	// Test: Failing command (exit 1)
 	app, _, stdout, _ = newTestApp()
-	require.Nil(t, app.Run([]string{"ntfy", "publish", "--wait-cmd", topic, "/bin/false", "false doesn't care about its args"}))
+	require.Nil(t, app.Run([]string{"ntfy", "publish", "--wait-cmd", topic, "false", "false doesn't care about its args"}))
 	m = toMessage(t, stdout.String())
 	require.Contains(t, m.Message, `Command failed after `)
-	require.Contains(t, m.Message, `(exit code 1): /bin/false "false doesn't care about its args"`, m.Message)
+	require.Contains(t, m.Message, `(exit code 1): false "false doesn't care about its args"`, m.Message)
 
 	// Test: Non-existing command (hard fail!)
 	app, _, _, _ = newTestApp()


### PR DESCRIPTION
This PR includes a set of optimizations and fixes for the Dockerfile, web build process, and macOS compatibility.

### Changes
* **Dockerfile Optimization:** Updated the Dockerfile to an optimized multi-stage build, switching the runner base image to `debian:bookworm-slim` for compatibility with bookworm-compiled binary, adding missing package directories (`ban`, `metrics`, `twilio`) to the builder stage, and configuring a default port `10000` and default CMD `serve`.
* **Web Build Fix:** Fixed the `web-build` target by ensuring the parent server directory is created before moving the build outputs.
* **macOS Fix:** Corrected the publish test path specifically for macOS environment compatibility.