### PR TITLE
Add Notidesk (Windows WinUI 3 client) to integrations

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -92,6 +92,7 @@ I've added a ⭐ to projects or posts that have a significant following, or had 
 - [ntfy-desktop](https://codeberg.org/zvava/ntfy-desktop) - Cross-platform desktop application for ntfy
 - [ntfy-desktop](https://github.com/Aetherinox/ntfy-desktop) - Desktop client for Windows, Linux, and MacOS with push notifications
 - [ntfy Desktop (Windows)](https://github.com/simoneferrari/ntfy-desktop) - Native Windows desktop client with multi-server support, toast notifications and message history, built with WPF and .NET (C#)
+- [Notidesk](https://github.com/onatakduman/ntfy-desktop-windows) - Native Windows desktop client built with WinUI 3, with toast notifications, tray support and publishing; available on the [Microsoft Store](https://apps.microsoft.com/detail/9PJDD0JKR719) (C#)
 - [wio-ntfy-ticker](https://github.com/nachotp/wio-ntfy-ticker) - Ticker display for a ntfy.sh topic
 - [ntfysh-windows](https://github.com/mshafer1/ntfysh-windows) - A ntfy client for Windows Desktop
 - [ntfyr](https://github.com/haxwithaxe/ntfyr) - A simple commandline tool to send notifications to ntfy


### PR DESCRIPTION
Hi! I built **Notidesk**, a native Windows desktop client for ntfy using WinUI 3 / Windows App SDK, and would love to have it listed in the CLIs + GUIs section.

It supports:

- Subscribing to topics on ntfy.sh or self-hosted servers, with access token or username/password auth per server
- Native Windows toast notifications with priority filtering and sounds
- Publishing with the full ntfy feature set (title, priority, tags, markdown, click URL, attachments, delayed delivery)
- Message history with attachments and action buttons
- System tray: keeps streaming in the background when the window is closed

Links:

- Source: https://github.com/onatakduman/ntfy-desktop-windows
- Microsoft Store: https://apps.microsoft.com/detail/9PJDD0JKR719

Thanks for building ntfy — happy to adjust the entry format if needed.