### PR TITLE
docs: add ntfy-logging to the Libraries section

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -85,6 +85,7 @@ I've added a ⭐ to projects or posts that have a significant following, or had 
 - [ntfy-java](https://github.com/MaheshBabu11/ntfy-java/) - A Java package to interact with a ntfy server (Java)
 - [aiontfy](https://github.com/tr4nt0r/aiontfy) - Asynchronous client library for publishing and subscribing to ntfy (Python)
 - [ex_ntfy](https://github.com/houllette/ex_ntfy) - Elixir SDK covering publishing, polling, and streaming subscriptions for ntfy servers (Elixir)
+- [ntfy-logging](https://github.com/Pimak/ntfy-logging) - Turns JVM error logs into ntfy notifications, with zero-code adapters for java.util.logging, Logback, Log4j2, Spring Boot, Micronaut and Quarkus (Java)
 
 ## CLIs + GUIs
 


### PR DESCRIPTION
Adds [ntfy-logging](https://github.com/Pimak/ntfy-logging) to the Libraries list, as the page invites.

It is a different shape from the ntfy clients already listed: rather than wrapping the API for you to call, it plugs into the JVM logging frameworks so ERROR-level log events become ntfy notifications with no calling code at all — `java.util.logging`, Logback, Log4j2, Spring Boot, Micronaut and a native-ready Quarkus extension, plus a plain programmatic client for arbitrary notifications.

A few things it does that seemed worth the entry:

- rate-limited with a suppressed-count digest, so an error storm collapses into one follow-up notification instead of flooding the topic;
- loop-safe — it never logs its own diagnostics back through the pipeline it publishes from;
- an opt-in `startup-ping` self-test that makes one real round-trip at boot and reports a clear cause ("the token may be revoked or expired", "url must be the base url with the topic NOT appended") rather than failing silently when the first real error arrives.

Apache-2.0, on Maven Central, documented at https://pimak.github.io/ntfy-logging/.