### PR TITLE
Poll notification database in iOS PWA

### DIFF
--- a/web/src/app/SubscriptionManager.js
+++ b/web/src/app/SubscriptionManager.js
@@ -188,6 +188,27 @@ export class SubscriptionManager {
       .toArray();
   }
 
+  /**
+   * Read a compact notification-table state directly from IndexedDB. This bypasses Dexie's
+   * reactive cache, which may not observe service-worker writes in an iOS standalone PWA.
+   */
+  async notificationStateFromBackend() {
+    await this.db.open();
+    const transaction = this.db.backendDB().transaction("notifications", "readonly");
+    const notifications = transaction.objectStore("notifications");
+    const countRequest = notifications.count();
+    const unreadCountRequest = notifications.index("new").count(1);
+    const latestRequest = notifications.index("time").openCursor(null, "prev");
+    const result = (request) =>
+      new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+
+    const [count, unreadCount, latest] = await Promise.all([result(countRequest), result(unreadCountRequest), result(latestRequest)]);
+    return { count, unreadCount, latestId: latest?.value?.id ?? null };
+  }
+
   /** Adds notification, or returns false if it already exists */
   async addNotification(subscriptionId, notification) {
     const exists = await this.db.notifications.get(notification.id);

--- a/web/src/app/SubscriptionManager.test.js
+++ b/web/src/app/SubscriptionManager.test.js
@@ -109,3 +109,35 @@ describe("SubscriptionManager.syncFromRemote", () => {
     expect(db.rows.get("https://ntfy.sh/mytopic").displayName).toBe("My Topic");
   });
 });
+
+describe("SubscriptionManager.notificationStateFromBackend", () => {
+  it("reads notification state through native IndexedDB requests", async () => {
+    const request = (value) => {
+      const indexedDbRequest = {};
+      queueMicrotask(() => {
+        indexedDbRequest.result = value;
+        indexedDbRequest.onsuccess();
+      });
+      return indexedDbRequest;
+    };
+    const notifications = {
+      count: () => request(4),
+      index: (name) => {
+        if (name === "new") {
+          return { count: () => request(2) };
+        }
+        return { openCursor: () => request({ value: { id: "newest" } }) };
+      },
+    };
+    const db = {
+      open: vi.fn(),
+      backendDB: () => ({
+        transaction: () => ({ objectStore: () => notifications }),
+      }),
+    };
+    const manager = new SubscriptionManager(db);
+
+    await expect(manager.notificationStateFromBackend()).resolves.toEqual({ count: 4, unreadCount: 2, latestId: "newest" });
+    expect(db.open).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/components/App.jsx
+++ b/web/src/components/App.jsx
@@ -14,7 +14,13 @@ import userManager from "../app/UserManager";
 import { expandUrl, getKebabCaseLangStr, darkModeEnabled, updateFavicon } from "../app/utils";
 import ErrorBoundary from "./ErrorBoundary";
 import routes from "./routes";
-import { useAccountListener, useBackgroundProcesses, useConnectionListeners, useWebPushTopics } from "./hooks";
+import {
+  useAccountListener,
+  useBackgroundProcesses,
+  useConnectionListeners,
+  useIOSNotificationDatabaseRevision,
+  useWebPushTopics,
+} from "./hooks";
 import PublishDialog from "./PublishDialog";
 import Messaging from "./Messaging";
 import Login from "./Login";
@@ -119,11 +125,12 @@ const Layout = () => {
   const { account, setAccount } = useContext(AccountContext);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [sendDialogOpenMode, setSendDialogOpenMode] = useState("");
+  const notificationDatabaseRevision = useIOSNotificationDatabaseRevision();
   const users = useLiveQuery(() => userManager.all());
-  const subscriptions = useLiveQuery(() => subscriptionManager.all());
+  const subscriptions = useLiveQuery(() => subscriptionManager.all(), [notificationDatabaseRevision]);
   // Preloaded here so the All view (and single topics, via filter) have data on mount -- no empty
   // frame when switching.
-  const allNotifications = useLiveQuery(() => subscriptionManager.getAllNotifications());
+  const allNotifications = useLiveQuery(() => subscriptionManager.getAllNotifications(), [notificationDatabaseRevision]);
   const webPushTopics = useWebPushTopics();
   const subscriptionsWithoutInternal = subscriptions?.filter((s) => !s.internal);
   const newNotificationsCount = subscriptionsWithoutInternal?.reduce((prev, cur) => prev + cur.new, 0) || 0;

--- a/web/src/components/hooks.js
+++ b/web/src/components/hooks.js
@@ -244,6 +244,55 @@ export const useWebPushTopics = () => {
 const matchMedia = window.matchMedia("(display-mode: standalone)");
 const isIOSStandalone = window.navigator.standalone === true;
 
+/**
+ * iOS may not propagate service-worker IndexedDB mutations to an already-running PWA. Poll a
+ * compact native IndexedDB snapshot while the PWA is visible and return a revision that can be
+ * used to re-run Dexie live queries when the snapshot changes.
+ */
+export const useIOSNotificationDatabaseRevision = () => {
+  const [revision, setRevision] = useState(0);
+
+  useEffect(() => {
+    if (!isIOSStandalone) {
+      return undefined;
+    }
+
+    let stopped = false;
+    let timeout;
+    let previousState;
+
+    const poll = async () => {
+      if (document.visibilityState === "visible") {
+        try {
+          const state = JSON.stringify(await subscriptionManager.notificationStateFromBackend());
+          if (stopped) {
+            return;
+          }
+          if (previousState !== undefined && state !== previousState) {
+            setRevision((current) => current + 1);
+          }
+          previousState = state;
+        } catch (e) {
+          console.error(`[useIOSNotificationDatabaseRevision] Error polling IndexedDB`, e);
+        }
+      }
+
+      if (!stopped) {
+        timeout = setTimeout(poll, 1000);
+      }
+    };
+
+    poll();
+
+    return () => {
+      stopped = true;
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  return revision;
+};
+
 /*
  * Watches the "display-mode" to detect if the app is running as a standalone app (PWA).
  */


### PR DESCRIPTION
On iOS PWA, periodically refresh the database for any changes from the Web Push Service Worker.

Fixes #1916; for an alternative approach, see #1917.

Verified with my own ntfy instance on iOS 27.