### PR TITLE
fix(client): resume from the last message after a dropped connection

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -24,6 +24,9 @@ const (
 
 const (
 	maxResponseBytes = 4096
+
+	subscribeRetryInitialDelay = 2 * time.Second
+	subscribeRetryMaxDelay     = 2 * time.Minute
 )
 
 var (
@@ -152,7 +155,7 @@ func (c *Client) Poll(topic string, options ...SubscribeOption) ([]*Message, err
 	log.Debug("%s Polling from topic", util.ShortTopicURL(topicURL))
 	options = append(options, WithPoll())
 	go func() {
-		err := performSubscribeRequest(ctx, msgChan, topicURL, "", options...)
+		_, err := performSubscribeRequest(ctx, msgChan, topicURL, "", options...)
 		close(msgChan)
 		errChan <- err
 	}()
@@ -226,58 +229,74 @@ func (c *Client) expandTopicURL(topic string) (string, error) {
 }
 
 func handleSubscribeConnLoop(ctx context.Context, msgChan chan *Message, topicURL, subcriptionID string, options ...SubscribeOption) {
+	var lastMessageID string
+	delay := subscribeRetryInitialDelay
 	for {
-		// TODO The retry logic is crude and may lose messages. It should record the last message like the
-		//      Android client, use since=, and do incremental backoff too
-		if err := performSubscribeRequest(ctx, msgChan, topicURL, subcriptionID, options...); err != nil {
+		attemptOptions := options
+		if lastMessageID != "" {
+			attemptOptions = append(append([]SubscribeOption{}, options...), WithSince(lastMessageID))
+		}
+		messageID, err := performSubscribeRequest(ctx, msgChan, topicURL, subcriptionID, attemptOptions...)
+		if messageID != "" {
+			lastMessageID = messageID
+		}
+		if err != nil {
 			log.Warn("%s Connection failed: %s", util.ShortTopicURL(topicURL), err.Error())
+		}
+		if err == nil || messageID != "" {
+			delay = subscribeRetryInitialDelay
 		}
 		select {
 		case <-ctx.Done():
 			log.Info("%s Connection exited", util.ShortTopicURL(topicURL))
 			return
-		case <-time.After(10 * time.Second): // TODO Add incremental backoff
+		case <-time.After(delay):
 		}
+		delay = min(2*delay, subscribeRetryMaxDelay)
 	}
 }
 
-func performSubscribeRequest(ctx context.Context, msgChan chan *Message, topicURL string, subscriptionID string, options ...SubscribeOption) error {
+// performSubscribeRequest returns the ID of the last message it handed to msgChan, so the caller can
+// resume from there rather than lose whatever arrived while the connection was down.
+func performSubscribeRequest(ctx context.Context, msgChan chan *Message, topicURL string, subscriptionID string, options ...SubscribeOption) (string, error) {
 	streamURL := fmt.Sprintf("%s/json", topicURL)
 	log.Debug("%s Listening to %s", util.ShortTopicURL(topicURL), streamURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
 	if err != nil {
-		return err
+		return "", err
 	}
 	for _, option := range options {
 		if err := option(req); err != nil {
-			return err
+			return "", err
 		}
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		b, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		if err != nil {
-			return err
+			return "", err
 		}
-		return errors.New(strings.TrimSpace(string(b)))
+		return "", errors.New(strings.TrimSpace(string(b)))
 	}
+	var lastMessageID string
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		messageJSON := scanner.Text()
 		m, err := toMessage(messageJSON, topicURL, subscriptionID)
 		if err != nil {
-			return err
+			return lastMessageID, err
 		}
 		log.Trace("%s Message received: %s", util.ShortTopicURL(topicURL), messageJSON)
 		if m.Event == MessageEvent {
 			msgChan <- m
+			lastMessageID = m.ID
 		}
 	}
-	return nil
+	return lastMessageID, nil
 }
 
 func toMessage(s, topicURL, subscriptionID string) (*Message, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,7 +6,10 @@ import (
 	"heckel.io/ntfy/v2/client"
 	"heckel.io/ntfy/v2/log"
 	"heckel.io/ntfy/v2/test"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -114,4 +117,47 @@ func nextMessage(c *client.Client) *client.Message {
 	default:
 		return nil
 	}
+}
+
+func TestClient_Subscribe_ResumeAfterConnectionLoss(t *testing.T) {
+	var mu sync.Mutex
+	since := make([]string, 0)
+	reconnected := make(chan struct{}, 1)
+	stop := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attempt := len(since)
+		since = append(since, r.URL.Query().Get("since"))
+		mu.Unlock()
+		if attempt == 0 {
+			fmt.Fprintln(w, `{"id":"nT4qA1zGvJ","time":1,"event":"message","topic":"mytopic","message":"delivered before the drop"}`)
+			return // ending the handler drops the stream, as a flaky connection would
+		}
+		select {
+		case reconnected <- struct{}{}:
+		default:
+		}
+		select {
+		case <-stop:
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+	defer close(stop)
+
+	c := client.New(client.NewConfig())
+	subscriptionID, _ := c.Subscribe(server.URL + "/mytopic")
+	defer c.Unsubscribe(subscriptionID)
+
+	select {
+	case <-reconnected:
+	case <-time.After(30 * time.Second):
+		t.Fatal("client did not reconnect")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "", since[0], "the first connection must not ask for old messages")
+	require.Equal(t, "nT4qA1zGvJ", since[1], "the reconnect must resume after the last delivered message")
 }


### PR DESCRIPTION
Closes #1895.

## Context

`handleSubscribeConnLoop` reconnected with exactly the options it started with, so the server replayed nothing and anything published while the connection was down was gone. On a flaky link (the reporter's example is a train) that is not an edge case, it is every reconnect. This is the loss the `TODO` in that function described.

## Changes

`performSubscribeRequest` now reports the ID of the last message it handed to the channel, and the loop passes that back as `since=` on the next attempt. `parseSince` already accepts a message ID, so the server resumes from the right point.

The fixed 10 second wait is replaced by a delay that starts at 2 seconds, doubles to a 2 minute ceiling, and resets whenever an attempt connects cleanly or delivers a message. That reconnects faster after a brief blip and stops hammering a server that is properly down.

## User impact

`ntfy subscribe` no longer silently drops messages across a reconnect, and it comes back within a couple of seconds after a short outage instead of always waiting ten.

## Verification

- New `TestClient_Subscribe_ResumeAfterConnectionLoss` serves one message, drops the stream, and asserts the second request carries `since=<that message's ID>`. On `main` it fails after 10.00s with `expected: "nT4qA1zGvJ", actual: ""`; with the change it passes in 2.00s, which also pins the new initial delay.
- `go build ./...`, `go vet ./client/...`, `gofmt -l` clean.
- `TestClient_Publish_Subscribe` and `TestClient_Publish_Poll` fail on this Windows host both before and after the change: they start a real server and `go-sqlite3` needs cgo, which this machine has no toolchain for. The new test does not need the server, so it runs here.

Two choices worth your call: the 2s/2min bounds, and resetting the backoff when an attempt merely connects rather than only when it delivers a message. Both are easy to change if you would rather have different numbers.