### PR TITLE
Support RFC 3339 timestamps for delays

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -49,6 +49,9 @@ ADD ./attachment ./attachment
 ADD ./mail ./mail
 ADD ./s3 ./s3
 ADD ./action ./action
+ADD ./ban ./ban
+ADD ./metrics ./metrics
+ADD ./twilio ./twilio
 ADD ./template/gotext ./template/gotext
 
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make VERSION=$VERSION COMMIT=$COMMIT cli-linux-server

--- a/util/time.go
+++ b/util/time.go
@@ -47,11 +47,27 @@ func ParseFutureTime(s string, now time.Time) (time.Time, error) {
 	if err == nil {
 		return t, nil
 	}
+	t, err = parseRFC3339Time(s, now)
+	if err == nil {
+		return t, nil
+	}
 	t, err = parseNaturalTime(s, now)
 	if err == nil {
 		return t, nil
 	}
 	return time.Time{}, errInvalidDuration
+}
+
+// parseRFC3339Time is a parser for time formated following RFC 3339
+func parseRFC3339Time(s string, now time.Time) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, errInvalidDuration
+	}
+	if !t.After(now) {
+		return time.Time{}, errInvalidDuration
+	}
+	return t, nil
 }
 
 // ParseDuration is like time.ParseDuration, except that it also understands days (d), which

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -116,3 +116,33 @@ func TestFormatDuration(t *testing.T) {
 func TestFormatDuration_Rounded(t *testing.T) {
 	require.Equal(t, "1d", FormatDuration(47*time.Hour))
 }
+
+func TestParseFutureTimeRFC3339(t *testing.T) {
+	now := time.Date(
+		2026, 9, 2,
+		7, 0, 0, 0,
+		time.UTC,
+	)
+
+	tests := []struct {
+		input    string
+		expected time.Time
+	}{
+		{
+			"2026-09-02T10:00:00Z",
+			time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			"2026-09-02T10:00:00+02:00",
+			time.Date(2026, 9, 2, 10, 0, 0, 0,
+				time.FixedZone("", 2*60*60)),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, err := ParseFutureTime(tt.input, now)
+		require.NoError(t, err)
+		require.True(t, tt.expected.Equal(actual),
+			"expected %v, got %v", tt.expected, actual)
+	}
+}


### PR DESCRIPTION
Add support for RFC 3339 timestamps in the Delay property, allowing messages to be scheduled at a precise point in time.