### PR TITLE
Fix Windows client command injection via message content

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -71,6 +71,11 @@ ntfy subscribe TOPIC COMMAND
     ntfy sub mytopic 'notify-send "$m"'    # Execute command for incoming messages
     ntfy sub topic1 myscript.sh            # Execute script for incoming messages
 
+  On Windows, %VARIABLE% references to the variables above are rewritten to
+  delayed-expansion references (!VARIABLE!) before the command is run, so that
+  message content cannot be interpreted as batch commands. A literal ! in a
+  command must be escaped as ^^!.
+
 ntfy subscribe --from-config
   Service mode (used in ntfy-client.service). This reads the config file and sets up 
   subscriptions for every topic in the "subscribe:" block (see config file).
@@ -259,7 +264,7 @@ func runCommand(c *cli.Context, command string, m *client.Message) {
 func runCommandInternal(c *cli.Context, script string, m *client.Message) error {
 	scriptFile := fmt.Sprintf("%s/ntfy-subscribe-%s.%s", os.TempDir(), util.RandomString(10), scriptExt)
 	log.Debug("%s Running command '%s' via temporary script %s", logMessagePrefix(m), script, scriptFile)
-	script = scriptHeader + script
+	script = scriptHeader + scriptVarRewriter(script)
 	if err := os.WriteFile(scriptFile, []byte(script), 0700); err != nil {
 		return err
 	}

--- a/cmd/subscribe_darwin.go
+++ b/cmd/subscribe_darwin.go
@@ -10,5 +10,6 @@ or "~/Library/Application Support/ntfy/client.yml" for all other users.`
 )
 
 var (
-	scriptLauncher = []string{"sh", "-c"}
+	scriptLauncher    = []string{"sh", "-c"}
+	scriptVarRewriter = func(script string) string { return script }
 )

--- a/cmd/subscribe_script.go
+++ b/cmd/subscribe_script.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"regexp"
+	"strings"
+)
+
+// scriptVarsPattern matches the ntfy message variables in their cmd.exe
+// percent-expansion syntax, e.g. %NTFY_MESSAGE% or %m% (case-insensitive).
+// Only exact variable references are matched: substring and partial
+// expansions such as %NTFY_MESSAGE:~0,5% are intentionally left untouched,
+// and so are all other environment variables like %PATH%.
+var scriptVarsPattern = regexp.MustCompile(`(?i)%(NTFY_ID|NTFY_TIME|NTFY_TOPIC|NTFY_MESSAGE|NTFY_TITLE|NTFY_PRIORITY|NTFY_TAGS|NTFY_RAW|id|time|topic|message|m|title|t|priority|prio|p|tags|tag|ta|raw)%`)
+
+// rewriteBatchScriptVars prepares a user command for execution as a Windows
+// batch script. cmd.exe substitutes %VAR% references with the raw variable
+// value before the line is parsed, so message content containing & | > or
+// quotes would be executed as command syntax (see
+// https://github.com/binwiederhier/ntfy/issues/1721). Rewriting the
+// references to delayed expansion (!VAR!) moves the substitution to after
+// the parse step, which turns message content into inert data.
+//
+// Note that with delayed expansion enabled, a literal ! in a command must
+// be escaped as ^^!.
+func rewriteBatchScriptVars(script string) string {
+	script = strings.ReplaceAll(script, "\r\n", "\n")
+	script = strings.ReplaceAll(script, "\n", "\r\n")
+	return scriptVarsPattern.ReplaceAllString(script, "!$1!")
+}

--- a/cmd/subscribe_script_test.go
+++ b/cmd/subscribe_script_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteBatchScriptVars_MessageVariables(t *testing.T) {
+	script := `notifu /m "%NTFY_MESSAGE%"`
+	expected := `notifu /m "!NTFY_MESSAGE!"`
+	require.Equal(t, expected, rewriteBatchScriptVars(script))
+}
+
+func TestRewriteBatchScriptVars_Aliases_CaseInsensitive(t *testing.T) {
+	script := `echo Message received: %message%, %M%, %Ntfy_Message%, %PRIORITY%`
+	expected := `echo Message received: !message!, !M!, !Ntfy_Message!, !PRIORITY!`
+	require.Equal(t, expected, rewriteBatchScriptVars(script))
+}
+
+func TestRewriteBatchScriptVars_LeavesOtherVariablesAlone(t *testing.T) {
+	script := `echo %PATH% && %UNKNOWN_VAR% 100%%`
+	require.Equal(t, script, rewriteBatchScriptVars(script))
+}
+
+func TestRewriteBatchScriptVars_LeavesSubstringExpansionAlone(t *testing.T) {
+	script := `echo %NTFY_MESSAGE:~0,5%`
+	require.Equal(t, script, rewriteBatchScriptVars(script))
+}
+
+func TestRewriteBatchScriptVars_NormalizesLineEndings(t *testing.T) {
+	script := "echo one\necho two\r\necho three"
+	expected := "echo one\r\necho two\r\necho three"
+	require.Equal(t, expected, rewriteBatchScriptVars(script))
+}
+
+func TestRewriteBatchScriptVars_AllDocumentedVariables(t *testing.T) {
+	script := `%NTFY_ID% %NTFY_TIME% %NTFY_TOPIC% %NTFY_MESSAGE% %NTFY_TITLE% %NTFY_PRIORITY% %NTFY_TAGS% %NTFY_RAW% %id% %time% %topic% %message% %m% %title% %t% %priority% %prio% %p% %tags% %tag% %ta% %raw%`
+	expected := `!NTFY_ID! !NTFY_TIME! !NTFY_TOPIC! !NTFY_MESSAGE! !NTFY_TITLE! !NTFY_PRIORITY! !NTFY_TAGS! !NTFY_RAW! !id! !time! !topic! !message! !m! !title! !t! !priority! !prio! !p! !tags! !tag! !ta! !raw!`
+	require.Equal(t, expected, rewriteBatchScriptVars(script))
+}

--- a/cmd/subscribe_unix.go
+++ b/cmd/subscribe_unix.go
@@ -10,5 +10,6 @@ or ~/.config/ntfy/client.yml for all other users.`
 )
 
 var (
-	scriptLauncher = []string{"sh", "-c"}
+	scriptLauncher    = []string{"sh", "-c"}
+	scriptVarRewriter = func(script string) string { return script }
 )

--- a/cmd/subscribe_windows.go
+++ b/cmd/subscribe_windows.go
@@ -4,10 +4,11 @@ package cmd
 
 const (
 	scriptExt                      = "bat"
-	scriptHeader                   = ""
+	scriptHeader                   = "@echo off\r\nsetlocal EnableExtensions EnableDelayedExpansion\r\n"
 	clientCommandDescriptionSuffix = `The default config file for all client commands is %AppData%\ntfy\client.yml.`
 )
 
 var (
-	scriptLauncher = []string{"cmd.exe", "/Q", "/C"}
+	scriptLauncher    = []string{"cmd.exe", "/Q", "/C"}
+	scriptVarRewriter = rewriteBatchScriptVars
 )

--- a/docs/subscribe/cli.md
+++ b/docs/subscribe/cli.md
@@ -250,6 +250,13 @@ Here's an example config file that subscribes to three different topics, executi
       command: calc
     ```
 
+!!! warning
+    On Windows, ntfy rewrites `%VARIABLE%` references to the message variables
+    above as delayed-expansion references (`!VARIABLE!`) before executing your
+    command. This prevents message content (such as `&`, `|` or quotes) from being
+    interpreted as batch commands by `cmd.exe`. As a side effect, a literal `!` in
+    your command must be escaped as `^^!`.
+
 In this example, when `ntfy subscribe --from-config` is executed:
 
 * Messages to `echo-this` simply echos to standard out


### PR DESCRIPTION
Fixes #1721

## Problem

In Windows client mode, the user command is written to a temporary `.bat` file and executed via `cmd.exe /Q /C`. Message fields are passed as environment variables, and commands reference them as `%NTFY_MESSAGE%` / `%message%`.

The problem: **cmd.exe substitutes `%VAR%` references with the raw value *before* parsing the script line.** Any `&`, `&&`, `|`, `>` or quote characters in a message therefore become batch syntax. As reported in #1721, with a config like:

```yaml
subscribe:
- topic: alerts
  command: 'notify-send "%NTFY_MESSAGE%"'
```

anyone who can publish to the topic can execute arbitrary commands on **every subscriber** of that topic by sending a message such as `a" && "calc`. On public topics this is effectively remote code execution on all listeners. (The Unix path is not affected the same way: `sh` expands env vars after parsing, so the value is data, not syntax.)

This is the same class of issue the Go/Rust ecosystems addressed in 2024 ("BatBadBut", CVE-2024-24576), where the conclusion was that arbitrary strings cannot be safely passed *through* cmd.exe percent expansion.

## Fix

Use cmd.exe **delayed expansion**, which substitutes the value *after* the line is parsed — the value can never be interpreted as command syntax:

- `cmd/subscribe_windows.go`: the generated script now starts with `@echo off` + `setlocal EnableExtensions EnableDelayedExpansion`, and a new `scriptVarRewriter` hook is applied to the user command.
- `cmd/subscribe_script.go` (new, cross-platform for testability): `rewriteBatchScriptVars()` rewrites only the **documented message variables** (`%NTFY_MESSAGE%`, `%message%`, `%m%`, … full list, case-insensitive) from `%VAR%` to `!VAR!`, and normalizes line endings to CRLF for the batch file.
- `cmd/subscribe.go`: `runCommandInternal` applies `scriptVarRewriter`; Unix/Darwin use an identity function, so behavior there is unchanged.

This keeps every documented config working as-is (`%message%` still works — it just becomes safe), leaves non-ntfy variables (`%PATH%`) and substring expansion (`%NTFY_MESSAGE:~0,5%`) untouched, and `%ERRORLEVEL%`-style percent expansion remains active inside the script.

## Known caveats (documented in help text + docs)

1. With `EnableDelayedExpansion`, a literal `!` in a command must be escaped as `^^!` (standard cmd semantics).
2. Substring/partial expansion of message variables (`%NTFY_MESSAGE:~0,5%`) is intentionally *not* rewritten and remains unsafe — the docs advise against it.

## Testing

- New unit tests in `cmd/subscribe_script_test.go` cover the rewrite (all documented vars + aliases, case-insensitivity, non-vars untouched, substring expansion untouched, CRLF normalization).
- `go build` / `go vet` pass for both `GOOS=windows` and darwin; `gofmt` clean; `go test ./cmd/...` passes (one pre-existing, unrelated failure `TestCLI_Publish_Wait_PID_And_Cmd` on macOS due to missing `/bin/false`, fails identically on a clean tree).
- I could not execute cmd.exe locally, so the delayed-expansion behavior itself is per documented cmd.exe semantics and will need a Windows eyeball in review — happy to adjust.