### PR TITLE
Set org.opencontainers.image.version label on release images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -156,6 +156,7 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--build-arg=VERSION={{ .Version }}"
   - image_templates:
       - &arm64v8_image "binwiederhier/ntfy:{{ .Tag }}-arm64v8"
     use: buildx
@@ -163,6 +164,7 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--build-arg=VERSION={{ .Version }}"
   - image_templates:
       - &armv7_image "binwiederhier/ntfy:{{ .Tag }}-armv7"
     use: buildx
@@ -171,6 +173,7 @@ dockers:
     goarm: 7
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--build-arg=VERSION={{ .Version }}"
   - image_templates:
       - &armv6_image "binwiederhier/ntfy:{{ .Tag }}-armv6"
     use: buildx
@@ -179,6 +182,7 @@ dockers:
     goarm: 6
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--build-arg=VERSION={{ .Version }}"
 docker_manifests:
   - name_template: "binwiederhier/ntfy:latest"
     image_templates:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
 
+ARG VERSION=dev
+
 LABEL org.opencontainers.image.authors="philipp.heckel@gmail.com"
 LABEL org.opencontainers.image.url="https://ntfy.sh/"
 LABEL org.opencontainers.image.documentation="https://docs.ntfy.sh/"
@@ -8,6 +10,7 @@ LABEL org.opencontainers.image.vendor="Philipp C. Heckel"
 LABEL org.opencontainers.image.licenses="Apache-2.0, GPL-2.0"
 LABEL org.opencontainers.image.title="ntfy"
 LABEL org.opencontainers.image.description="Send push notifications to your phone or desktop using PUT/POST"
+LABEL org.opencontainers.image.version="$VERSION"
 
 RUN apk add --no-cache tzdata
 COPY ntfy /usr/bin

--- a/Dockerfile-arm
+++ b/Dockerfile-arm
@@ -1,5 +1,7 @@
 FROM alpine
 
+ARG VERSION=dev
+
 LABEL org.opencontainers.image.authors="philipp.heckel@gmail.com"
 LABEL org.opencontainers.image.url="https://ntfy.sh/"
 LABEL org.opencontainers.image.documentation="https://docs.ntfy.sh/"
@@ -8,6 +10,7 @@ LABEL org.opencontainers.image.vendor="Philipp C. Heckel"
 LABEL org.opencontainers.image.licenses="Apache-2.0, GPL-2.0"
 LABEL org.opencontainers.image.title="ntfy"
 LABEL org.opencontainers.image.description="Send push notifications to your phone or desktop using PUT/POST"
+LABEL org.opencontainers.image.version="$VERSION"
 
 # Alpine does not support adding "tzdata" on ARM anymore, see
 # https://github.com/binwiederhier/ntfy/issues/894


### PR DESCRIPTION
Fixes #1921.

## Problem

The published Docker images (`binwiederhier/ntfy`) are missing the `org.opencontainers.image.version` label. Verified against the registry: the `latest` image config carries 8 `org.opencontainers.image.*` labels but no version, so image updaters cannot tell which ntfy release they are running.

PR #1307 added the `LABEL` to `Dockerfile-build`, but that file is not part of the release pipeline: in `.goreleaser.yml`, the amd64 image is built from `Dockerfile` and the arm images from `Dockerfile-arm`, and neither had the label or a `VERSION` build arg.

## Change

- `Dockerfile` / `Dockerfile-arm`: add `ARG VERSION=dev` and `LABEL org.opencontainers.image.version="$VERSION"` next to the existing labels
- `.goreleaser.yml`: pass `--build-arg=VERSION={{ .Version }}` in each of the four `build_flag_templates`, so the real version from the release tag lands in the image config

`Dockerfile-build` already had the label and is left as is.

After this, `docker inspect binwiederhier/ntfy:v2.x.y --format '{{ .Config.Labels.org_opencontainers_image_version }}'` returns the release version instead of empty.